### PR TITLE
Don't leak PrivateKeyStringResource private keys via toString()

### DIFF
--- a/src/main/java/net/schmizz/sshj/userauth/password/PrivateKeyStringResource.java
+++ b/src/main/java/net/schmizz/sshj/userauth/password/PrivateKeyStringResource.java
@@ -29,4 +29,11 @@ public class PrivateKeyStringResource extends Resource<String> {
     public Reader getReader() throws IOException {
         return new StringReader(getDetail());
     }
+
+    @Override
+    public String toString() {
+        // If not overridden, the superclass's will return the private key as
+        // part of the string.
+        return "[" + getClass().getSimpleName() + "]";
+    }
 }


### PR DESCRIPTION
This is necessary to prevent dumping the whole private key into the log in the case of an authentication exception
