### PR TITLE
Fixed bug in SFTP FileMode for AIX/Unix directory mask

### DIFF
--- a/src/main/java/net/schmizz/sshj/sftp/FileMode.java
+++ b/src/main/java/net/schmizz/sshj/sftp/FileMode.java
@@ -74,7 +74,7 @@ public class FileMode {
     }
 
     public int getTypeMask() {
-        return mask & 0770000;
+        return mask & 0170000;
     }
 
     public int getPermissionsMask() {

--- a/src/test/java/net/schmizz/sshj/sftp/FileModeTest.java
+++ b/src/test/java/net/schmizz/sshj/sftp/FileModeTest.java
@@ -1,0 +1,23 @@
+package net.schmizz.sshj.sftp;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class FileModeTest {
+
+	@Test
+	public void shouldDetectDirectoryWithLinuxMask() {
+		FileMode fileMode = new FileMode(040755);
+		assertThat(fileMode.toString(), equalTo("[mask=40755]"));
+		assertThat(fileMode.getType(), equalTo(FileMode.Type.DIRECTORY));
+	}
+
+	@Test
+	public void shouldDetectDirectoryWithAixUnixMask() {
+		FileMode fileMode = new FileMode(0240755);
+		assertThat(fileMode.toString(), equalTo("[mask=240755]"));
+		assertThat(fileMode.getType(), equalTo(FileMode.Type.DIRECTORY));
+	}
+}


### PR DESCRIPTION
In Overthere running against AIX/Unix we discovered that FileMode uses the wrong type mask for detecting the file type. Instead of 170000 it is using 770000. Please see the attached fix and tests.

See also: https://github.com/xebialabs/overthere/issues/14
