### PR TITLE
Added upload filter capability to SCPUploadClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
             <version>0.9.29</version>
             <scope>test</scope>
         </dependency>
+	    <dependency>
+		    <groupId>org.mockito</groupId>
+		    <artifactId>mockito-all</artifactId>
+		    <version>1.9.0-rc1</version>
+		    <scope>test</scope>
+	    </dependency>
     </dependencies>
 
 

--- a/src/main/java/net/schmizz/sshj/xfer/scp/SCPUploadClient.java
+++ b/src/main/java/net/schmizz/sshj/xfer/scp/SCPUploadClient.java
@@ -16,6 +16,7 @@
 package net.schmizz.sshj.xfer.scp;
 
 import net.schmizz.sshj.common.IOUtils;
+import net.schmizz.sshj.xfer.LocalFileFilter;
 import net.schmizz.sshj.xfer.LocalSourceFile;
 import net.schmizz.sshj.xfer.scp.SCPEngine.Arg;
 
@@ -28,8 +29,9 @@ import java.util.List;
 public final class SCPUploadClient {
 
     private final SCPEngine engine;
+	private LocalFileFilter uploadFilter;
 
-    SCPUploadClient(SCPEngine engine) {
+	SCPUploadClient(SCPEngine engine) {
         this.engine = engine;
     }
 
@@ -45,7 +47,11 @@ public final class SCPUploadClient {
         return engine.getExitStatus();
     }
 
-    private synchronized void startCopy(LocalSourceFile sourceFile, String targetPath)
+	public void setUploadFilter(LocalFileFilter uploadFilter) {
+		this.uploadFilter = uploadFilter;
+	}
+
+	private synchronized void startCopy(LocalSourceFile sourceFile, String targetPath)
             throws IOException {
         List<Arg> args = new LinkedList<Arg>();
         args.add(Arg.SINK);
@@ -75,7 +81,7 @@ public final class SCPUploadClient {
             throws IOException {
         preserveTimeIfPossible(f);
         engine.sendMessage("D0" + getPermString(f) + " 0 " + f.getName());
-        for (LocalSourceFile child : f.getChildren(null))
+        for (LocalSourceFile child : f.getChildren(uploadFilter))
             process(child);
         engine.sendMessage("E");
     }

--- a/src/test/java/net/schmizz/sshj/xfer/scp/SCPUploadClientTest.java
+++ b/src/test/java/net/schmizz/sshj/xfer/scp/SCPUploadClientTest.java
@@ -1,0 +1,54 @@
+package net.schmizz.sshj.xfer.scp;
+
+import net.schmizz.sshj.xfer.FileSystemFile;
+import net.schmizz.sshj.xfer.LocalFileFilter;
+import net.schmizz.sshj.xfer.LocalSourceFile;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.verification.VerificationMode;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.mockito.Matchers.endsWith;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class SCPUploadClientTest {
+
+	private SCPEngine engine;
+	private SCPUploadClient scpUploadClient;
+
+	@Rule
+	public TemporaryFolder temp = new TemporaryFolder();
+
+	@Before
+	public void init() {
+		engine = mock(SCPEngine.class);
+		scpUploadClient = new SCPUploadClient(engine);
+	}
+
+	@Test
+	public void shouldOnlySendFilterAcceptedFilesFromDirectory() throws IOException {
+		scpUploadClient.setUploadFilter(new LocalFileFilter() {
+			@Override
+			public boolean accept(LocalSourceFile file) {
+				return !file.getName().contains("not-");
+			}
+		});
+
+		File dir = temp.newFolder("filtered-scp-upload");
+		new File(dir, "not-sent.txt").createNewFile();
+		new File(dir, "sent.txt").createNewFile();
+
+		int copy = scpUploadClient.copy(new FileSystemFile(dir), "/tmp");
+		verify(engine).startedDir("filtered-scp-upload");
+		verify(engine).startedFile(eq("sent.txt"), isA(Long.class));
+		verify(engine, times(1)).startedFile(isA(String.class), isA(Long.class));
+	}
+}


### PR DESCRIPTION
Hi Shikhar,

I got a question from an SSHJ user whether it is possible to do filtering of uploaded directories using SCP, see: http://stackoverflow.com/questions/7467869/setting-file-filters-when-doing-uploading-and-downloading-of-files-in-sshj-v0-5-0

I've added this (removed) functionality again in SCPUploadClient in this pull request. It might be nice to add this back in, as your SFTP implementation does support this.

Regards,
Jeroen
