### PR TITLE
Remove bouncycastle version range from OSGi metadata.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
                             javax.crypto*,
                             com.jcraft.jzlib*;version="[1.0,2)",
                             org.slf4j*;version="[1.6,2)",
-                            org.bouncycastle*;version="[1.4,2)",
+                            org.bouncycastle*,
                             *
                         </Import-Package>
                         <Export-Package>net.schmizz.*</Export-Package>


### PR DESCRIPTION
The OSGi MANIFEST.MF specifies a version range for bouncycastle.
However, bouncy castle official bundles do not export versioned packages (use version 0.0.0) and thus its impossible to use them along with sshj.

It has been tested with jclouds 1.2.3 and in fact is required for using the jclouds sshj module inside OSGi.
