### PR TITLE
Set default tty to vt100, as specified in the javadoc

### DIFF
--- a/src/main/java/net/schmizz/sshj/connection/channel/direct/SessionChannel.java
+++ b/src/main/java/net/schmizz/sshj/connection/channel/direct/SessionChannel.java
@@ -75,7 +75,7 @@ public class SessionChannel
     @Override
     public void allocateDefaultPTY()
             throws ConnectionException, TransportException {
-        allocatePTY("dummy", 80, 24, 0, 0, Collections.<PTYMode, Integer>emptyMap());
+        allocatePTY("vt100", 80, 24, 0, 0, Collections.<PTYMode, Integer>emptyMap());
     }
 
     @Override


### PR DESCRIPTION
In the SessionChannel  the default tty is set to 'dummy' which is a non-existing terminal type on most (if not all systems). As per the JavaDoc, the default should be 'vt100' which is a sensible default. This ensures that sshj is compatible with almost any *Nix system and Windows ssh daemon.
