### PR TITLE
SFTP client no longer tries to create folders twice when path has trailing separator

### DIFF
--- a/src/main/java/net/schmizz/sshj/sftp/SFTPClient.java
+++ b/src/main/java/net/schmizz/sshj/sftp/SFTPClient.java
@@ -90,6 +90,7 @@ public class SFTPClient
     public void mkdirs(String path)
             throws IOException {
         final Deque<String> dirsToMake = new LinkedList<String>();
+        path = PathComponents.trimTrailingSeparator(path, engine.getPathHelper().getPathSeparator());
         for (PathComponents current = engine.getPathHelper().getComponents(path); ;
              current = engine.getPathHelper().getComponents(current.getParent())) {
             final FileAttributes attrs = statExistence(current.getPath());

--- a/src/test/java/net/schmizz/sshj/sftp/SFTPClientTest.java
+++ b/src/test/java/net/schmizz/sshj/sftp/SFTPClientTest.java
@@ -1,0 +1,36 @@
+package net.schmizz.sshj.sftp;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static net.schmizz.sshj.sftp.PathHelper.DEFAULT_PATH_SEPARATOR;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SFTPClientTest {
+    private final SFTPEngine sftpEngine = mock(SFTPEngine.class);
+    private final SFTPClient client = new SFTPClient(sftpEngine);
+
+    @Before
+    public void setPathHelper() throws Exception {
+        PathHelper helper = new PathHelper(sftpEngine, DEFAULT_PATH_SEPARATOR);
+        when(sftpEngine.getPathHelper()).thenReturn(helper);
+    }
+
+    @Before
+    public void setRemoteWorkingDirectory() throws IOException {
+        when(sftpEngine.canonicalize(".")).thenReturn("/workingdirectory");
+        FileAttributes isADirectory = new FileAttributes.Builder().withType(FileMode.Type.DIRECTORY).build();
+        when(sftpEngine.stat("/workingdirectory")).thenReturn(isADirectory);
+    }
+
+    @Test
+    public void doesNotTryToCreateDirectoryTwiceWhenPathHasTrailingSeparator() throws Exception {
+        client.mkdirs("/folder/directory/");
+        verify(sftpEngine, times(1)).makeDir("/folder/directory");
+    }
+}


### PR DESCRIPTION
Working with SSHJ, @signed and me discovered that `SFTPClient.mkdirs` tries to create the deepest folder twice when the path argument ends with the separator character.
This change fixes it.

The change might better belong into `PathHelper.getComponents`, but we decide against it, lest we trigger unforeseen consequences.
