### PR TITLE
Updated bouncycastle dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,14 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk16</artifactId>
-            <version>1.46</version>
-            <scope>provided</scope>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.47</version>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.47</version>
+        </dependency> 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
Bouncycastle release 1.47 is now available. Please note that now bouncycastle comes in 2 jars (bcprov and bcpkix)
