### PR TITLE
Update bouncycastle to 1.50

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.49</version>
+            <version>1.50</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.49</version>
+            <version>1.50</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-core</artifactId>
-            <version>0.8.0</version>
+            <version>0.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Update bouncycastle to the latest version 1.50. And since sshd-core 0.8.0 doesn't play well with latest bouncycastle, update it as well.

I took inspiration from [this](http://mail-archives.apache.org/mod_mbox/camel-commits/201312.mbox/%3C383957136d2d46d38de7b51ca5030eaf@git.apache.org%3E).
