### PR TITLE
* bouncycastle to 1.50, jzlib to 1.1.3 & sshd-core to 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,19 +54,19 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.49</version>
+            <version>1.50</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jzlib</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-core</artifactId>
-            <version>0.8.0</version>
+            <version>0.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -202,12 +202,12 @@
                 <dependency>
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
-                    <version>1.49</version>
+                    <version>1.50</version>
                 </dependency>
                 <dependency>
                     <groupId>com.jcraft</groupId>
                     <artifactId>jzlib</artifactId>
-                    <version>1.0.7</version>
+                    <version>1.1.3</version>
                 </dependency>
                 <dependency>
                     <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
update bouncycastle to 1.50 (3rd December 2013) 
http://www.bouncycastle.org/latest_releases.html
http://mvnrepository.com/artifact/org.bouncycastle/bcpg-jdk15on/1.50 (java 1.5->1.7)

jzlib to 1.1.3 (Oct 02, 2013) 
http://www.jcraft.com/jzlib/
https://github.com/ymnk/jzlib (java 1.5)

sshd-core 0.11.0
http://mina.apache.org/sshd-project/index.html

(https://github.com/JEBailey/jzlib)
