### PR TITLE
Added right bracket to pom.xml on <jdk>-tag to fix issue with ant build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
         <profile>
             <id>doclint-java8-disable</id>
             <activation>
-                <jdk>[1.8,</jdk>
+                <jdk>[1.8,)</jdk>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
One of my colleagues @mikepenz found an issue inside the pom.xml. We're using jcloud and they have this project as dependency. After 4 hours on debugging why our ant build is failing, we found that the current notation for this plugin is invalid.

This pull request fixes this issue.
