### PR TITLE
Use long for Channel#await timeout

### DIFF
--- a/src/main/java/net/schmizz/sshj/connection/channel/AbstractChannel.java
+++ b/src/main/java/net/schmizz/sshj/connection/channel/AbstractChannel.java
@@ -254,7 +254,7 @@ public abstract class AbstractChannel
         closeEvent.await();
     }
 
-    public void join(int timeout, TimeUnit unit)
+    public void join(long timeout, TimeUnit unit)
             throws ConnectionException {
         closeEvent.await(timeout, unit);
     }

--- a/src/main/java/net/schmizz/sshj/connection/channel/Channel.java
+++ b/src/main/java/net/schmizz/sshj/connection/channel/Channel.java
@@ -131,7 +131,7 @@ public interface Channel
     void join()
             throws ConnectionException;
 
-    void join(int timeout, TimeUnit unit)
+    void join(long timeout, TimeUnit unit)
             throws ConnectionException;
 
 }


### PR DESCRIPTION
This matches the underlying method called by `AbstractChannel` and is the standard for timeouts with a `TimeUnit`.
