### PR TITLE
Add ability to change the protocol prefix string

### DIFF
--- a/src/main/java/net/schmizz/sshj/Config.java
+++ b/src/main/java/net/schmizz/sshj/Config.java
@@ -88,6 +88,13 @@ public interface Config {
     String getVersion();
 
     /**
+     * Returns the protocol prefix string sent to and expected from the server during SSH connection initialization.
+     * This is almost always {@code "SSH"}, but may be different when connecting to embedded servers that follow the
+     * SSH protocol but give it a different name.
+     */
+    String getProtocolPrefix();
+
+    /**
      * Set the named factories for {@link Cipher}.
      *
      * @param cipherFactories a list of named factories
@@ -143,5 +150,13 @@ public interface Config {
      * @param version software version info
      */
     void setVersion(String version);
+
+    /**
+     * Returns the protocol prefix string sent to and expected from the server during SSH connection initialization.
+     * For example, an embedded server may follow the SSH protocol but change the name to {@code "XYZ"}.
+     *
+     * @param protocolPrefix the protocol prefix
+     */
+    void setProtocolPrefix(String protocolPrefix);
 
 }

--- a/src/main/java/net/schmizz/sshj/ConfigImpl.java
+++ b/src/main/java/net/schmizz/sshj/ConfigImpl.java
@@ -32,6 +32,7 @@ public class ConfigImpl
         implements Config {
 
     private String version;
+    private String protocolPrefix;
 
     private Factory<Random> randomFactory;
 
@@ -41,6 +42,7 @@ public class ConfigImpl
     private List<Factory.Named<MAC>> macFactories;
     private List<Factory.Named<Signature>> signatureFactories;
     private List<Factory.Named<FileKeyProvider>> fileKeyProviderFactories;
+
 
     @Override
     public List<Factory.Named<Cipher>> getCipherFactories() {
@@ -80,6 +82,11 @@ public class ConfigImpl
     @Override
     public String getVersion() {
         return version;
+    }
+
+    @Override
+    public String getProtocolPrefix() {
+        return protocolPrefix;
     }
 
     public void setCipherFactories(Factory.Named<Cipher>... cipherFactories) {
@@ -144,6 +151,11 @@ public class ConfigImpl
     @Override
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    @Override
+    public void setProtocolPrefix(String protocolPrefix) {
+        this.protocolPrefix = protocolPrefix;
     }
 
 }

--- a/src/main/java/net/schmizz/sshj/DefaultConfig.java
+++ b/src/main/java/net/schmizz/sshj/DefaultConfig.java
@@ -69,7 +69,8 @@ import java.util.List;
  * <li>{@link net.schmizz.sshj.ConfigImpl#setRandomFactory PRNG}: {@link net.schmizz.sshj.transport.random.BouncyCastleRandom}* or {@link net.schmizz.sshj.transport.random.JCERandom}</li>
  * <li>{@link net.schmizz.sshj.ConfigImpl#setFileKeyProviderFactories Key file support}: {@link net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile}*, {@link
  * net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile}*</li>
- * <li>{@link net.schmizz.sshj.ConfigImpl#setVersion Client version}: {@code "NET_3_0"}</li>
+ * <li>{@link net.schmizz.sshj.ConfigImpl#setVersion Client version}: {@code "SSHJ_0_9_2"}</li>
+ * <li>{@link net.schmizz.sshj.ConfigImpl#setProtocolPrefix Protocol prefix}: {@code "SSH"}</li>
  * </ul>
  * <p/>
  * [1] It is worth noting that Sun's JRE does not have the unlimited cryptography extension enabled by default. This
@@ -81,9 +82,11 @@ public class DefaultConfig
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private static final String VERSION = "SSHJ_0_9_2";
+    private static final String PROTOCOL_PREFIX = "SSH";
 
     public DefaultConfig() {
         setVersion(VERSION);
+        setProtocolPrefix(PROTOCOL_PREFIX);
         final boolean bouncyCastleRegistered = SecurityUtils.isBouncyCastleRegistered();
         initKeyExchangeFactories(bouncyCastleRegistered);
         initRandomFactory(bouncyCastleRegistered);


### PR DESCRIPTION
I realize that this is a very niche feature, but I have a use case where it is required so perhaps others might as well. For context, I have an application that runs a modified Dropbear SSH server that follows the SSH protocol, but changes the protocol identification string to something else. I'm using SSHJ to communicate with both this server and standard SSH servers based on some configuration, so I needed a way to switch the protocol string without including multiple libraries.

Feel free to decline this and I'll just leave this change in my fork.