### PR TITLE
Fix scp interaction with windows server

### DIFF
--- a/src/main/java/net/schmizz/sshj/xfer/scp/SCPEngine.java
+++ b/src/main/java/net/schmizz/sshj/xfer/scp/SCPEngine.java
@@ -106,7 +106,7 @@ class SCPEngine {
         if (path == null || path.isEmpty())
             cmd.append(".");
         else
-            cmd.append("'").append(path.replaceAll("'", "\\'")).append("'");
+            cmd.append("\"").append(path.replaceAll("'", "\\'")).append("\"");
         scp = host.startSession().exec(cmd.toString());
     }
 


### PR DESCRIPTION
locale machine - linux
remote machine - windows (with winsshd server)

Command line is ok:

		user@linux:~$scp ugl@192.168.10.188:C:/qwerty/file.exe /tmp
		ugl@192.168.10.188's password: 
		file.exe                                  100%   54KB  53.5KB/s   00:00

sshj before fix:

		public static void main(String[] args) throws Exception {
			String host = "192.168.10.188";
			String username = "ugl";
			String password = "123";
			String remotePath = "C:/qwerty/file.exe";
			String localPath = "/tmp/";
			SSHClient ssh = new SSHClient();
			ssh.setConnectTimeout(10);
			ssh.loadKnownHosts();
			ssh.connect(host);
			ssh.authPassword(username, password);
			ssh.newSCPFileTransfer().download(remotePath, new FileSystemFile(localPath));
			ssh.close();
		}

		Exception in thread "main" net.schmizz.sshj.xfer.scp.SCPException: Could not parse message ``
			at net.schmizz.sshj.xfer.scp.SCPDownloadClient.process(SCPDownloadClient.java:100)
			at net.schmizz.sshj.xfer.scp.SCPDownloadClient.startCopy(SCPDownloadClient.java:75)
			at net.schmizz.sshj.xfer.scp.SCPDownloadClient.copy(SCPDownloadClient.java:46)
			at net.schmizz.sshj.xfer.scp.SCPFileTransfer.download(SCPFileTransfer.java:64)
			at net.schmizz.sshj.xfer.scp.Test.main(Test.java:71)

sshj with fix is ok.
