### PR TITLE
fixed block sizes for hmac-sha2-256 and hmac-sha2-512

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -26,7 +26,7 @@ signatures::
   `ssh-rsa`, `ssh-dss`
 
 mac::
-  `hmac-md5`, `hmac-md5-96`, `hmac-sha1`, `hmac-sha1-96`
+  `hmac-md5`, `hmac-md5-96`, `hmac-sha1`, `hmac-sha1-96`, `hmac-sha2-256`, `hmac-sha2-512`
 
 compression::
   `zlib` and `zlib@openssh.com` (delayed zlib)

--- a/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
+++ b/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
@@ -310,11 +310,11 @@ final class KeyExchanger
 
         final MAC mac_C2S = Factory.Named.Util.create(transport.getConfig().getMACFactories(), negotiatedAlgs
                 .getClient2ServerMACAlgorithm());
-        mac_C2S.init(integrityKey_C2S);
+        mac_C2S.init(resizedKey(integrityKey_C2S, mac_C2S.getBlockSize(), hash, kex.getK(), kex.getH()));
 
         final MAC mac_S2C = Factory.Named.Util.create(transport.getConfig().getMACFactories(),
                                                       negotiatedAlgs.getServer2ClientMACAlgorithm());
-        mac_S2C.init(integrityKey_S2C);
+        mac_S2C.init(resizedKey(integrityKey_S2C, mac_S2C.getBlockSize(), hash, kex.getK(), kex.getH()));
 
         final Compression compression_S2C =
                 Factory.Named.Util.create(transport.getConfig().getCompressionFactories(),

--- a/src/main/java/net/schmizz/sshj/transport/mac/HMACSHA2256.java
+++ b/src/main/java/net/schmizz/sshj/transport/mac/HMACSHA2256.java
@@ -35,6 +35,6 @@ public class HMACSHA2256
     }
 
     public HMACSHA2256() {
-        super("HmacSHA256", 20, 20);
+        super("HmacSHA256", 32, 32);
     }
 }

--- a/src/main/java/net/schmizz/sshj/transport/mac/HMACSHA2512.java
+++ b/src/main/java/net/schmizz/sshj/transport/mac/HMACSHA2512.java
@@ -35,6 +35,6 @@ public class HMACSHA2512
     }
 
     public HMACSHA2512() {
-        super("HmacSHA512", 20, 20);
+        super("HmacSHA512", 64, 64);
     }
 }


### PR DESCRIPTION
These MACs where added in fdb891b842 but they didn't work for me after disabling md5&sha1. The server simply didn't respond anymore eventually resulting in a timeout. I debugged this and found two issues with the current code:

* both MACs have to use larger block/digest sizes, the previous values were the same that SHA1 had, but SHA2 needs 32 or 64 byte
* Additionally the KeyExchanger would only generate a 20 byte key when using diffie-hellman with sha1 as a KEX. For SHA2 larger keys are used, so the first message with a mac resulted in a "Corrupted MAC on input" error on the server. So the keys had to be resized like its already done for the Ciphers.