### PR TITLE
Fixed unbounded range in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
         <profile>
             <id>doclint-java8-disable</id>
             <activation>
-                <jdk>[1.8,</jdk>
+                <jdk>[1.8,)</jdk>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
When using the actual snap in another project I get the following maven error:

> [INFO] Failed to resolve artifact.
> 
> Unable to get dependency information: Unable to read the metadata file for artifact 'net.schmizz:sshj:jar': Invalid JDK version in profile 'doclint-java8-disable': Unbounded range: [1.8, for project net.schmizz:sshj
>   net.schmizz:sshj:jar:0.10.1-SNAPSHOT

Fixed by bounding the version range.