### PR TITLE
added unit-tests for the "mac"-package

### DIFF
--- a/src/test/java/net/schmizz/sshj/transport/mac/BaseMacTest.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/BaseMacTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2009 sshj contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.schmizz.sshj.transport.mac;
+
+import net.schmizz.sshj.common.SSHRuntimeException;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class BaseMacTest {
+    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
+    private static final String EXPECTED_HMAC = "24ddeed57ad91465c5b59dce74ef73778bfb0cb9";
+    private static final String KEY = "et1Quo5ooCie6theel8i";
+
+    @Test
+    public void testResizeTooBigKeys() {
+        BaseMAC hmac = new HMACSHA1();
+        hmac.init((KEY + "foo").getBytes(CHARSET));
+        hmac.update(PLAIN_TEXT);
+        assertThat(Hex.toHexString(hmac.doFinal()),  is(EXPECTED_HMAC));
+    }
+
+    @Test(expected = SSHRuntimeException.class)
+    public void testUnknownAlgorithm() {
+        // hopefully a algorithm with that name won't be created :-)
+        BaseMAC hmac = new BaseMAC("AlgorithmThatDoesNotExist", 20, 20);
+        hmac.init((KEY + "foo").getBytes(CHARSET));
+        hmac.update(PLAIN_TEXT);
+        assertThat(Hex.toHexString(hmac.doFinal()),  is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testUpdateWithDoFinal() {
+        BaseMAC hmac = initHmac();
+        hmac.update(PLAIN_TEXT);
+        assertThat(Hex.toHexString(hmac.doFinal()),  is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testUpdateWithRange() {
+        BaseMAC hmac = initHmac();
+
+        // a leading and trailing byte to the plaintext
+        byte[] plainText = new byte[PLAIN_TEXT.length + 2];
+        System.arraycopy(PLAIN_TEXT, 0, plainText, 1, PLAIN_TEXT.length);
+
+        // update with the range from the second to penultimate byte
+        hmac.update(plainText, 1, PLAIN_TEXT.length);
+        assertThat(Hex.toHexString(hmac.doFinal()),  is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testDoFinalWithInput() {
+        BaseMAC hmac = initHmac();
+        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testUpdateWithDoFinalWithResultBuffer() {
+        BaseMAC hmac = initHmac();
+        byte[] resultBuf = new byte[20];
+        hmac.update(PLAIN_TEXT);
+        hmac.doFinal(resultBuf, 0);
+        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+    }
+
+    private BaseMAC initHmac() {
+        BaseMAC hmac = new HMACSHA1();
+        hmac.init(KEY.getBytes(CHARSET));
+        return hmac;
+    }
+}

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACMD596Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACMD596Test.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2009 sshj contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.schmizz.sshj.transport.mac;
+
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HMACMD596Test {
+    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
+    private static final String EXPECTED_HMAC = "dff33c507463f9cf088a5ce8";
+
+    @Test
+    @Ignore
+    public void testUpdateWithDoFinal() {
+        HMACMD596 hmac = initHmac();
+        hmac.update(PLAIN_TEXT);
+        assertThat(Hex.toHexString(hmac.doFinal()), is(EXPECTED_HMAC));
+    }
+
+    @Test
+    @Ignore
+    public void testDoFinalWithInput() {
+        HMACMD596 hmac = initHmac();
+        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)),
+                is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testUpdateWithDoFinalWithResultBuffer() {
+        HMACMD596 hmac = initHmac();
+        byte[] resultBuf = new byte[12];
+        hmac.update(PLAIN_TEXT);
+        hmac.doFinal(resultBuf, 0);
+        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+    }
+
+    private HMACMD596 initHmac() {
+        HMACMD596 hmac = new HMACMD596();
+        hmac.init("ohBahfei6pee5dai".getBytes(CHARSET));
+        return hmac;
+    }
+}

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACMD5Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACMD5Test.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2009 sshj contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.schmizz.sshj.transport.mac;
+
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HMACMD5Test {
+    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
+    private static final String EXPECTED_HMAC = "dff33c507463f9cf088a5ce8d969c386";
+
+    @Test
+    public void testUpdateWithDoFinal() {
+        HMACMD5 hmac = initHmac();
+        hmac.update(PLAIN_TEXT);
+        assertThat(Hex.toHexString(hmac.doFinal()), is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testDoFinalWithInput() {
+        HMACMD5 hmac = initHmac();
+        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testUpdateWithDoFinalWithResultBuffer() {
+        HMACMD5 hmac = initHmac();
+        byte[] resultBuf = new byte[16];
+        hmac.update(PLAIN_TEXT);
+        hmac.doFinal(resultBuf, 0);
+        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+    }
+
+    private HMACMD5 initHmac() {
+        HMACMD5 hmac = new HMACMD5();
+        hmac.init("ohBahfei6pee5dai".getBytes(CHARSET));
+        return hmac;
+    }
+}

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA196Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA196Test.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2009 sshj contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.schmizz.sshj.transport.mac;
+
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HMACSHA196Test {
+    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
+    private static final String EXPECTED_HMAC = "24ddeed57ad91465c5b59dce";
+
+    @Test
+    @Ignore
+    public void testUpdateWithDoFinal() {
+        HMACSHA196 hmac = initHmac();
+        hmac.update(PLAIN_TEXT);
+        assertThat(Hex.toHexString(hmac.doFinal()), is(EXPECTED_HMAC));
+    }
+
+    @Test
+    @Ignore
+    public void testDoFinalWithInput() {
+        HMACSHA196 hmac = initHmac();
+        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testUpdateWithDoFinalWithResultBuffer() {
+        HMACSHA196 hmac = initHmac();
+        byte[] resultBuf = new byte[12];
+        hmac.update(PLAIN_TEXT);
+        hmac.doFinal(resultBuf, 0);
+        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+    }
+
+    private HMACSHA196 initHmac() {
+        HMACSHA196 hmac = new HMACSHA196();
+        hmac.init("et1Quo5ooCie6theel8i".getBytes(CHARSET));
+        return hmac;
+    }
+}

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA1Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA1Test.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2009 sshj contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.schmizz.sshj.transport.mac;
+
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HMACSHA1Test {
+    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
+    private static final String EXPECTED_HMAC = "24ddeed57ad91465c5b59dce74ef73778bfb0cb9";
+
+    @Test
+    public void testUpdateWithDoFinal() {
+        HMACSHA1 hmac = initHmac();
+        hmac.update(PLAIN_TEXT);
+        assertThat(Hex.toHexString(hmac.doFinal()),  is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testDoFinalWithInput() {
+        HMACSHA1 hmac = initHmac();
+        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testUpdateWithDoFinalWithResultBuffer() {
+        HMACSHA1 hmac = initHmac();
+        byte[] resultBuf = new byte[20];
+        hmac.update(PLAIN_TEXT);
+        hmac.doFinal(resultBuf, 0);
+        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+    }
+
+    private HMACSHA1 initHmac() {
+        HMACSHA1 hmac = new HMACSHA1();
+        hmac.init("et1Quo5ooCie6theel8i".getBytes(CHARSET));
+        return hmac;
+    }
+}

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA2256Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA2256Test.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2009 sshj contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.schmizz.sshj.transport.mac;
+
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HMACSHA2256Test {
+    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
+    private static final String EXPECTED_HMAC = "eb2207b2df36c7485f46d1be30418bc44e8134b4fdaabbe16d71f56ab24fce88";
+
+    @Test
+    public void testUpdateWithDoFinal() {
+        HMACSHA2256 hmac = initHmac();
+        hmac.update(PLAIN_TEXT);
+        assertThat(Hex.toHexString(hmac.doFinal()), is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testDoFinalWithInput() {
+        HMACSHA2256 hmac = initHmac();
+        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testUpdateWithDoFinalWithResultBuffer() {
+        HMACSHA2256 hmac = initHmac();
+        byte[] resultBuf = new byte[32];
+        hmac.update(PLAIN_TEXT);
+        hmac.doFinal(resultBuf, 0);
+        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+    }
+
+    private HMACSHA2256 initHmac() {
+        HMACSHA2256 hmac = new HMACSHA2256();
+        hmac.init("koopiegh4reengah1que9Wiew7ohahPh".getBytes(CHARSET));
+        return hmac;
+    }
+}

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA2512Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA2512Test.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2009 sshj contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.schmizz.sshj.transport.mac;
+
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class HMACSHA2512Test {
+    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
+    private static final String EXPECTED_HMAC = "28929cffc903039ef18cbc9cea6fd5f1420763af297a470d731236ed1f5a4c61d64dfccf6529265205bec932f2f7850c8ae4de1dc1a5259dc5b1fd85d8e62c04";
+
+    @Test
+    public void testUpdateWithDoFinal() {
+        HMACSHA2512 hmac = initHmac();
+        hmac.update(PLAIN_TEXT);
+        assertThat(Hex.toHexString(hmac.doFinal()), is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testDoFinalWithInput() {
+        HMACSHA2512 hmac = initHmac();
+        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+    }
+
+    @Test
+    public void testUpdateWithDoFinalWithResultBuffer() {
+        HMACSHA2512 hmac = initHmac();
+        byte[] resultBuf = new byte[64];
+        hmac.update(PLAIN_TEXT);
+        hmac.doFinal(resultBuf, 0);
+        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+    }
+
+    private HMACSHA2512 initHmac() {
+        HMACSHA2512 hmac = new HMACSHA2512();
+        hmac.init("paishiengu1jaeTie5OoTu2eib7Kohqueicie7ahLohfoothahpeivi5weik1EiB".getBytes(CHARSET));
+        return hmac;
+    }
+}


### PR DESCRIPTION
As wished in #156 here are some unittests, for the HMACs at least. I'll try to look into creating a test for the KeyExchanger when I've got time.

While I was at it I created tests for all classes in the "mac"-package. This way I also found a bug in BaseMac which will be fixed with another PR (this is why some of the tests are currently disabled in HMACSHA196Test and HMACMD596Test).

The tests all create a hmac of "Hello World" with a random key of the expected size. I cross-checked the results with two different online services for hmacs.