### PR TITLE
Detect end-of-stream in TransportImpl#init

### DIFF
--- a/src/main/java/net/schmizz/sshj/transport/TransportImpl.java
+++ b/src/main/java/net/schmizz/sshj/transport/TransportImpl.java
@@ -158,7 +158,10 @@ public final class TransportImpl
             // Read server's ID
             final Buffer.PlainBuffer buf = new Buffer.PlainBuffer();
             while ((serverID = readIdentification(buf)).isEmpty()) {
-                buf.putByte((byte) connInfo.in.read());
+                int b = connInfo.in.read();
+                if (b == -1)
+                    throw new TransportException("Server closed connection during identification exchange");
+                buf.putByte((byte) b);
             }
 
             log.info("Server identity string: {}", serverID);


### PR DESCRIPTION
OpenSSH will drop connections based on the value of `MaxStartups` when there are too many unauthenticated connection. When this happens, reads on the client socket return -1, which was previously inserted into the identification buffer, leading to the error in #118. This doesn't fix that issue, but hopefully makes it clear that it is a server problem, not a client problem.