### PR TITLE
bugfix: match complete host instead of contains on the hoststring

### DIFF
--- a/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
@@ -352,7 +352,7 @@ public class OpenSSHKnownHosts
         @Override
         public boolean appliesTo(KeyType type, String host)
                 throws IOException {
-            return type == this.type && hostnames.contains(host);
+            return type == this.type && hosts.contains(host);
         }
     }
 

--- a/src/test/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHostsTest.java
+++ b/src/test/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHostsTest.java
@@ -29,6 +29,7 @@ import java.security.PublicKey;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -78,6 +79,7 @@ public class OpenSSHKnownHostsTest {
 
         assertTrue(kh.verify("schmizz.net", 22, key));
         assertTrue(kh.verify("69.163.155.180", 22, key));
+        assertFalse(kh.verify("69.163.155.18", 22, key));
     }
 
     @Test


### PR DESCRIPTION
The SimpleEntry currently matches the hostname of the connection against
the complete hoststring of the entry. This way substrings also match, so
for example "10.0.0.1" matches on an entry for "10.0.0.10", resulting in
a host-key-changed message if the key differs which is usually does.