### PR TITLE
Reintrodusing end of file when closing

### DIFF
--- a/src/main/java/net/schmizz/sshj/connection/channel/ChannelOutputStream.java
+++ b/src/main/java/net/schmizz/sshj/connection/channel/ChannelOutputStream.java
@@ -172,7 +172,7 @@ public final class ChannelOutputStream
         if (!closed) {
             try {
                 buffer.flush(false);
-//                trans.write(new SSHPacket(Message.CHANNEL_EOF).putUInt32(chan.getRecipient()));
+                trans.write(new SSHPacket(Message.CHANNEL_EOF).putUInt32(chan.getRecipient()));
             } finally {
                 closed = true;
             }


### PR DESCRIPTION
Since this was commented out without any explanation and it causes problems when using pipes it should be reintroduced. If a good explanation for leaving it disabled exists could you please provide it?