### PR TITLE
Modifications for working with SSH gateways

### DIFF
--- a/src/main/java/net/schmizz/sshj/SSHClient.java
+++ b/src/main/java/net/schmizz/sshj/SSHClient.java
@@ -139,7 +139,7 @@ public class SSHClient
     /** {@code ssh-connection} service */
     protected final Connection conn;
 
-    private List<LocalPortForwarder> forwarders;
+    private final List<LocalPortForwarder> forwarders = new ArrayList<LocalPortForwarder>();
 
     /** Default constructor. Initializes this object using {@link DefaultConfig}. */
     public SSHClient() {
@@ -433,15 +433,14 @@ public class SSHClient
     @Override
     public void disconnect()
             throws IOException {
-        if (forwarders != null) {
-            for (LocalPortForwarder forwarder : forwarders) {
-                try {
-                    forwarder.close();
-                } catch (IOException e) {
-                    log.warn("Error closing forwarder", e);
-                }
+        for (LocalPortForwarder forwarder : forwarders) {
+            try {
+                forwarder.close();
+            } catch (IOException e) {
+                log.warn("Error closing forwarder", e);
             }
         }
+        forwarders.clear();
         trans.disconnect();
         super.disconnect();
     }
@@ -659,9 +658,6 @@ public class SSHClient
      */
     public LocalPortForwarder newLocalPortForwarder(LocalPortForwarder.Parameters parameters,
                                                     ServerSocket serverSocket) {
-        if (forwarders == null) {
-            forwarders = new ArrayList<LocalPortForwarder>();
-        }
         LocalPortForwarder forwarder = new LocalPortForwarder(conn, parameters, serverSocket);
         forwarders.add(forwarder);
         return forwarder;

--- a/src/main/java/net/schmizz/sshj/SocketClient.java
+++ b/src/main/java/net/schmizz/sshj/SocketClient.java
@@ -118,18 +118,26 @@ public abstract class SocketClient {
     }
 
     public void connect(String hostname, int port) throws IOException {
-        this.hostname = hostname;
-        socket = socketFactory.createSocket();
-        socket.connect(new InetSocketAddress(hostname, port), connectTimeout);
-        onConnect();
+        if (hostname == null) {
+            connect(InetAddress.getByName(null), port);
+        } else {
+            this.hostname = hostname;
+            socket = socketFactory.createSocket();
+            socket.connect(new InetSocketAddress(hostname, port), connectTimeout);
+            onConnect();
+        }
     }
 
     public void connect(String hostname, int port, InetAddress localAddr, int localPort) throws IOException {
-        this.hostname = hostname;
-        socket = socketFactory.createSocket();
-        socket.bind(new InetSocketAddress(localAddr, localPort));
-        socket.connect(new InetSocketAddress(hostname, port), connectTimeout);
-        onConnect();
+        if (hostname == null) {
+            connect(InetAddress.getByName(null), port, localAddr, localPort);
+        } else {
+            this.hostname = hostname;
+            socket = socketFactory.createSocket();
+            socket.bind(new InetSocketAddress(localAddr, localPort));
+            socket.connect(new InetSocketAddress(hostname, port), connectTimeout);
+            onConnect();
+        }
     }
 
     public void connect(InetAddress host) throws IOException {

--- a/src/main/java/net/schmizz/sshj/SocketClient.java
+++ b/src/main/java/net/schmizz/sshj/SocketClient.java
@@ -48,12 +48,50 @@ public abstract class SocketClient {
         this.defaultPort = defaultPort;
     }
 
-    public void connect(InetAddress host, int port) throws IOException {
-        socket = socketFactory.createSocket();
-        socket.connect(new InetSocketAddress(host, port), connectTimeout);
+    /**
+     * Connect to a host via a proxy.
+     * @param hostname The host name to connect to.
+     * @param proxy The proxy to connect via.
+     * @deprecated This method will be removed after v0.12.0. If you want to connect via a proxy, you can do this by injecting a {@link javax.net.SocketFactory}
+     *             into the SocketClient. The SocketFactory should create sockets using the {@link java.net.Socket#Socket(java.net.Proxy)} constructor.
+     */
+    @Deprecated
+    public void connect(String hostname, Proxy proxy) throws IOException {
+        connect(hostname, defaultPort, proxy);
+    }
+
+    /**
+     * Connect to a host via a proxy.
+     * @param hostname The host name to connect to.
+     * @param port The port to connect to.
+     * @param proxy The proxy to connect via.
+     * @deprecated This method will be removed after v0.12.0. If you want to connect via a proxy, you can do this by injecting a {@link javax.net.SocketFactory}
+     *             into the SocketClient. The SocketFactory should create sockets using the {@link java.net.Socket#Socket(java.net.Proxy)} constructor.
+     */
+    @Deprecated
+    public void connect(String hostname, int port, Proxy proxy) throws IOException {
+        this.hostname = hostname;
+        if (JavaVersion.isJava7OrEarlier() && proxy.type() == Proxy.Type.HTTP) {
+            // Java7 and earlier have no support for HTTP Connect proxies, return our custom socket.
+            socket = new Jdk7HttpProxySocket(proxy);
+        } else {
+            socket = new Socket(proxy);
+        }
+        socket.connect(new InetSocketAddress(hostname, port), connectTimeout);
         onConnect();
     }
 
+    /**
+     * Connect to a host via a proxy.
+     * @param host The host address to connect to.
+     * @param proxy The proxy to connect via.
+     * @deprecated This method will be removed after v0.12.0. If you want to connect via a proxy, you can do this by injecting a {@link javax.net.SocketFactory}
+     *             into the SocketClient. The SocketFactory should create sockets using the {@link java.net.Socket#Socket(java.net.Proxy)} constructor.
+     */
+    @Deprecated
+    public void connect(InetAddress host, Proxy proxy) throws IOException {
+        connect(host, defaultPort, proxy);
+    }
 
     /**
      * Connect to a host via a proxy.
@@ -75,23 +113,33 @@ public abstract class SocketClient {
         onConnect();
     }
 
-    public void connect(String hostname, int port) throws IOException {
-        this.hostname = hostname;
-        connect(InetAddress.getByName(hostname), port);
+    public void connect(String hostname) throws IOException {
+        connect(hostname, defaultPort);
     }
 
-    /**
-     * Connect to a host via a proxy.
-     * @param hostname The host name to connect to.
-     * @param port The port to connect to.
-     * @param proxy The proxy to connect via.
-     * @deprecated This method will be removed after v0.12.0. If you want to connect via a proxy, you can do this by injecting a {@link javax.net.SocketFactory}
-     *             into the SocketClient. The SocketFactory should create sockets using the {@link java.net.Socket#Socket(java.net.Proxy)} constructor.
-     */
-    @Deprecated
-    public void connect(String hostname, int port, Proxy proxy) throws IOException {
+    public void connect(String hostname, int port) throws IOException {
         this.hostname = hostname;
-        connect(InetAddress.getByName(hostname), port, proxy);
+        socket = socketFactory.createSocket();
+        socket.connect(new InetSocketAddress(hostname, port), connectTimeout);
+        onConnect();
+    }
+
+    public void connect(String hostname, int port, InetAddress localAddr, int localPort) throws IOException {
+        this.hostname = hostname;
+        socket = socketFactory.createSocket();
+        socket.bind(new InetSocketAddress(localAddr, localPort));
+        socket.connect(new InetSocketAddress(hostname, port), connectTimeout);
+        onConnect();
+    }
+
+    public void connect(InetAddress host) throws IOException {
+        connect(host, defaultPort);
+    }
+
+    public void connect(InetAddress host, int port) throws IOException {
+        socket = socketFactory.createSocket();
+        socket.connect(new InetSocketAddress(host, port), connectTimeout);
+        onConnect();
     }
 
     public void connect(InetAddress host, int port, InetAddress localAddr, int localPort)
@@ -100,43 +148,6 @@ public abstract class SocketClient {
         socket.bind(new InetSocketAddress(localAddr, localPort));
         socket.connect(new InetSocketAddress(host, port), connectTimeout);
         onConnect();
-    }
-
-    public void connect(String hostname, int port, InetAddress localAddr, int localPort) throws IOException {
-        this.hostname = hostname;
-        connect(InetAddress.getByName(hostname), port, localAddr, localPort);
-    }
-
-    public void connect(InetAddress host) throws IOException {
-        connect(host, defaultPort);
-    }
-
-    public void connect(String hostname) throws IOException {
-        connect(hostname, defaultPort);
-    }
-
-    /**
-     * Connect to a host via a proxy.
-     * @param host The host address to connect to.
-     * @param proxy The proxy to connect via.
-     * @deprecated This method will be removed after v0.12.0. If you want to connect via a proxy, you can do this by injecting a {@link javax.net.SocketFactory}
-     *             into the SocketClient. The SocketFactory should create sockets using the {@link java.net.Socket#Socket(java.net.Proxy)} constructor.
-     */
-    @Deprecated
-    public void connect(InetAddress host, Proxy proxy) throws IOException {
-        connect(host, defaultPort, proxy);
-    }
-
-    /**
-     * Connect to a host via a proxy.
-     * @param hostname The host name to connect to.
-     * @param proxy The proxy to connect via.
-     * @deprecated This method will be removed after v0.12.0. If you want to connect via a proxy, you can do this by injecting a {@link javax.net.SocketFactory}
-     *             into the SocketClient. The SocketFactory should create sockets using the {@link java.net.Socket#Socket(java.net.Proxy)} constructor.
-     */
-    @Deprecated
-    public void connect(String hostname, Proxy proxy) throws IOException {
-        connect(hostname, defaultPort, proxy);
     }
 
     public void disconnect() throws IOException {


### PR DESCRIPTION
In the spirit of keeping PRs functionally-targeted, submitted for your approval are a few changes pertaining to working with SSH gateways and proxies.

First, I re-ordered the connect methods in SocketClient.java, so that all the String-based and InetAddress-based methods would be grouped together (so that I wouldn't have to jump around in the file when working on them).  Then, I eliminated all use of InetAddress.getByName in the String-based connect methods, because when you're connecting through a gateway or Proxy you may not actually have the ability to resolve the DNS name of the target host (but the Proxy or gateway will).

I also added some lightweight management of LocalPortForwarders to the SSHClient class, because when the client is closed, I want any LocalPortForwarders that are using the client's transport to also be closed.  This makes it possible to have a stateless SocketFactory that connects Sockets through an SSH gateway (SocketFactories being the preferred method of implementing connections through gateways in sshj).

I considered having the SSHClient class actually manage the ServerSockets and listener threads associated with LocalPortForwarders (as JSch does), but thought you might not want that.  So for now I'm doing all that in a SocketFactory class that sits outside of the sshj project.