### PR TITLE
Compatibility features

### DIFF
--- a/src/main/java/net/schmizz/sshj/SSHClient.java
+++ b/src/main/java/net/schmizz/sshj/SSHClient.java
@@ -212,7 +212,7 @@ public class SSHClient
     public void auth(String username, Iterable<AuthMethod> methods)
             throws UserAuthException, TransportException {
         checkConnected();
-        final Deque<UserAuthException> savedEx = new LinkedList<>();
+        final Deque<UserAuthException> savedEx = new LinkedList<UserAuthException>();
         for (AuthMethod method: methods) {
             method.setLoggerFactory(loggerFactory);
             try {
@@ -334,7 +334,7 @@ public class SSHClient
      */
     public void authPublickey(String username, Iterable<KeyProvider> keyProviders)
             throws UserAuthException, TransportException {
-        final List<AuthMethod> am = new LinkedList<>();
+        final List<AuthMethod> am = new LinkedList<AuthMethod>();
         for (KeyProvider kp : keyProviders)
             am.add(new AuthPublickey(kp));
         auth(username, am);
@@ -377,7 +377,7 @@ public class SSHClient
      */
     public void authPublickey(String username, String... locations)
             throws UserAuthException, TransportException {
-        final List<KeyProvider> keyProviders = new LinkedList<>();
+        final List<KeyProvider> keyProviders = new LinkedList<KeyProvider>();
         for (String loc : locations) {
             try {
                 log.debug("Attempting to load key from: {}", loc);
@@ -407,7 +407,7 @@ public class SSHClient
     public void authGssApiWithMic(String username, LoginContext context, Oid supportedOid, Oid... supportedOids)
             throws UserAuthException, TransportException {
         // insert supportedOid to the front of the list since ordering matters
-        List<Oid> oids = new ArrayList<>(Arrays.asList(supportedOids));
+        List<Oid> oids = new ArrayList<Oid>(Arrays.asList(supportedOids));
         oids.add(0, supportedOid);
 
         auth(username, new AuthGssApiWithMic(context, oids));

--- a/src/main/java/net/schmizz/sshj/connection/channel/AbstractChannel.java
+++ b/src/main/java/net/schmizz/sshj/connection/channel/AbstractChannel.java
@@ -52,6 +52,8 @@ public abstract class AbstractChannel
     /** Remote recipient ID */
     private int recipient;
 
+    private boolean eof = false;
+
     private final Queue<Event<ConnectionException>> chanReqResponseEvents = new LinkedList<Event<ConnectionException>>();
 
     /* The lock used by to create the open & close events */
@@ -189,6 +191,11 @@ public abstract class AbstractChannel
                 gotUnknown(msg, buf);
 
         }
+    }
+
+    @Override
+    public boolean isEOF() {
+	return eof;
     }
 
     @Override
@@ -394,6 +401,7 @@ public abstract class AbstractChannel
     /** Called when EOF has been received. Subclasses can override but must call super. */
     protected void eofInputStreams() {
         in.eof();
+	eof = true;
     }
 
     @Override

--- a/src/main/java/net/schmizz/sshj/connection/channel/AbstractChannel.java
+++ b/src/main/java/net/schmizz/sshj/connection/channel/AbstractChannel.java
@@ -195,12 +195,12 @@ public abstract class AbstractChannel
 
     @Override
     public boolean isEOF() {
-	return eof;
+        return eof;
     }
 
     @Override
     public LoggerFactory getLoggerFactory() {
-	return loggerFactory;
+        return loggerFactory;
     }
 
     private void gotClose()
@@ -401,7 +401,7 @@ public abstract class AbstractChannel
     /** Called when EOF has been received. Subclasses can override but must call super. */
     protected void eofInputStreams() {
         in.eof();
-	eof = true;
+        eof = true;
     }
 
     @Override

--- a/src/main/java/net/schmizz/sshj/connection/channel/Channel.java
+++ b/src/main/java/net/schmizz/sshj/connection/channel/Channel.java
@@ -136,6 +136,11 @@ public interface Channel
             throws ConnectionException;
 
     /**
+     * Returns whether EOF has been received.
+     */
+    boolean isEOF();
+
+    /**
      * Get the LoggerFactory associated with the SSH client.
      */
     LoggerFactory getLoggerFactory();

--- a/src/main/java/net/schmizz/sshj/sftp/FileMode.java
+++ b/src/main/java/net/schmizz/sshj/sftp/FileMode.java
@@ -36,7 +36,7 @@ public class FileMode {
         /** directory */
         DIRECTORY(0040000),
         /** symbolic link */
-        SYMKLINK(0120000),
+        SYMLINK(0120000),
         /** unknown */
         UNKNOWN(0);
 

--- a/src/main/java/net/schmizz/sshj/sftp/Response.java
+++ b/src/main/java/net/schmizz/sshj/sftp/Response.java
@@ -30,7 +30,30 @@ public final class Response
         BAD_MESSAGE(5),
         NO_CONNECTION(6),
         CONNECITON_LOST(7),
-        OP_UNSUPPORTED(8);
+        OP_UNSUPPORTED(8),
+        INVALID_HANDLE(9),
+        NO_SUCH_PATH(10),
+        FILE_ALREADY_EXISTS(11),
+        WRITE_PROTECT(12),
+        NO_MEDIA(13),
+        NO_SPACE_ON_FILESYSTEM(14),
+        QUOTA_EXCEEDED(15),
+        UNKNOWN_PRINCIPAL(16),
+        LOCK_CONFLICT(17),
+        DIR_NOT_EMPTY(18),
+        NOT_A_DIRECTORY(19),
+        INVALID_FILENAME(20),
+        LINK_LOOP(21),
+        CANNOT_DELETE(22),
+        INVALID_PARAMETER(23),
+        FILE_IS_A_DIRECTORY(24),
+        BYTE_RANGE_LOCK_CONFLICT(25),
+        BYTE_RANGE_LOCK_REFUSED(26),
+        DELETE_PENDING(27),
+        FILE_CORRUPT(28),
+        OWNER_INVALID(29),
+        GROUP_INVALID(30),
+        NO_MATCHING_BYTE_RANGE_LOCK(31);
 
         private final int code;
 

--- a/src/main/java/net/schmizz/sshj/sftp/SFTPClient.java
+++ b/src/main/java/net/schmizz/sshj/sftp/SFTPClient.java
@@ -86,7 +86,7 @@ public class SFTPClient
 
     public void mkdirs(String path)
             throws IOException {
-        final Deque<String> dirsToMake = new LinkedList<>();
+        final Deque<String> dirsToMake = new LinkedList<String>();
         for (PathComponents current = engine.getPathHelper().getComponents(path); ;
              current = engine.getPathHelper().getComponents(current.getParent())) {
             final FileAttributes attrs = statExistence(current.getPath());


### PR DESCRIPTION
These are the remaining changes I had to add to sshj for compatibility with Joval's jSAF provider code.  They're all relatively minor so I hope it makes sense to group them together:
1) Re-wrote try-with-resources and inferred generics constructors (no functional changes) so that the project can be built using Java 6.
2) Added a method to the Channel interface to make it possible to determine whether an EOF has been received.
3) Added some missing SFTP response codes.
5) Fixed a typo in an SFTP enum.