### PR TITLE
Gracefully load OpenSSH known_hosts without requiring BouncyCastle

### DIFF
--- a/src/main/java/net/schmizz/sshj/common/Buffer.java
+++ b/src/main/java/net/schmizz/sshj/common/Buffer.java
@@ -426,8 +426,18 @@ public class Buffer<T extends Buffer<T>> {
     public PublicKey readPublicKey()
             throws BufferException {
         try {
-            final String type = readString();
-            return KeyType.fromString(type).readPubKeyFromBuffer(type, this);
+            final KeyType type = KeyType.fromString(readString());
+            switch(type) {
+              case RSA:
+              case DSA:
+                return type.readPubKeyFromBuffer(this);
+              default:
+                if (SecurityUtils.isBouncyCastleRegistered()) {
+                    return type.readPubKeyFromBuffer(this);
+                } else {
+                    throw new BufferException("BouncyCastle is required to read a key of type " + type);
+                }
+            }
         } catch (GeneralSecurityException e) {
             throw new SSHRuntimeException(e);
         }

--- a/src/main/java/net/schmizz/sshj/common/Buffer.java
+++ b/src/main/java/net/schmizz/sshj/common/Buffer.java
@@ -427,16 +427,16 @@ public class Buffer<T extends Buffer<T>> {
             throws BufferException {
         try {
             final KeyType type = KeyType.fromString(readString());
-            switch(type) {
-              case RSA:
-              case DSA:
-                return type.readPubKeyFromBuffer(this);
-              default:
-                if (SecurityUtils.isBouncyCastleRegistered()) {
+            switch (type) {
+                case RSA:
+                case DSA:
                     return type.readPubKeyFromBuffer(this);
-                } else {
-                    throw new BufferException("BouncyCastle is required to read a key of type " + type);
-                }
+                default:
+                    if (SecurityUtils.isBouncyCastleRegistered()) {
+                        return type.readPubKeyFromBuffer(this);
+                    } else {
+                        throw new BufferException("BouncyCastle is required to read a key of type " + type);
+                    }
             }
         } catch (GeneralSecurityException e) {
             throw new SSHRuntimeException(e);

--- a/src/main/java/net/schmizz/sshj/common/Buffer.java
+++ b/src/main/java/net/schmizz/sshj/common/Buffer.java
@@ -426,18 +426,7 @@ public class Buffer<T extends Buffer<T>> {
     public PublicKey readPublicKey()
             throws BufferException {
         try {
-            final KeyType type = KeyType.fromString(readString());
-            switch (type) {
-                case RSA:
-                case DSA:
-                    return type.readPubKeyFromBuffer(this);
-                default:
-                    if (SecurityUtils.isBouncyCastleRegistered()) {
-                        return type.readPubKeyFromBuffer(this);
-                    } else {
-                        throw new BufferException("BouncyCastle is required to read a key of type " + type);
-                    }
-            }
+            return KeyType.fromString(readString()).readPubKeyFromBuffer(this);
         } catch (GeneralSecurityException e) {
             throw new SSHRuntimeException(e);
         }

--- a/src/main/java/net/schmizz/sshj/common/KeyType.java
+++ b/src/main/java/net/schmizz/sshj/common/KeyType.java
@@ -116,6 +116,9 @@ public enum KeyType {
         @Override
         public PublicKey readPubKeyFromBuffer(Buffer<?> buf)
                 throws GeneralSecurityException {
+            if (!SecurityUtils.isBouncyCastleRegistered()) {
+                throw new GeneralSecurityException("BouncyCastle is required to read a key of type " + sType);
+            }
             try {
                 // final String algo = buf.readString();  it has been already read
                 final String curveName = buf.readString();

--- a/src/main/java/net/schmizz/sshj/common/KeyType.java
+++ b/src/main/java/net/schmizz/sshj/common/KeyType.java
@@ -46,7 +46,7 @@ public enum KeyType {
     /** SSH identifier for RSA keys */
     RSA("ssh-rsa") {
         @Override
-        public PublicKey readPubKeyFromBuffer(String type, Buffer<?> buf)
+        public PublicKey readPubKeyFromBuffer(Buffer<?> buf)
                 throws GeneralSecurityException {
             final BigInteger e, n;
             try {
@@ -77,7 +77,7 @@ public enum KeyType {
     /** SSH identifier for DSA keys */
     DSA("ssh-dss") {
         @Override
-        public PublicKey readPubKeyFromBuffer(String type, Buffer<?> buf)
+        public PublicKey readPubKeyFromBuffer(Buffer<?> buf)
                 throws GeneralSecurityException {
             BigInteger p, q, g, y;
             try {
@@ -114,7 +114,7 @@ public enum KeyType {
         private final Logger log = LoggerFactory.getLogger(getClass());
 
         @Override
-        public PublicKey readPubKeyFromBuffer(String type, Buffer<?> buf)
+        public PublicKey readPubKeyFromBuffer(Buffer<?> buf)
                 throws GeneralSecurityException {
             try {
                 // final String algo = buf.readString();  it has been already read
@@ -127,7 +127,7 @@ public enum KeyType {
                 buf.readRawBytes(y);
                 if(log.isDebugEnabled()) {
                     log.debug(String.format("Key algo: %s, Key curve: %s, Key Len: %s, 0x04: %s\nx: %s\ny: %s",
-                            type,
+                            sType,
                             curveName,
                             keyLen,
                             x04,
@@ -176,14 +176,14 @@ public enum KeyType {
     ED25519("ssh-ed25519") {
         private final Logger log = LoggerFactory.getLogger(KeyType.class);
         @Override
-        public PublicKey readPubKeyFromBuffer(String type, Buffer<?> buf) throws GeneralSecurityException {
+        public PublicKey readPubKeyFromBuffer(Buffer<?> buf) throws GeneralSecurityException {
             try {
                 final int keyLen = buf.readUInt32AsInt();
                 final byte[] p = new byte[keyLen];
                 buf.readRawBytes(p);
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("Key algo: %s, Key curve: 25519, Key Len: %s\np: %s",
-                            type,
+                            sType,
                             keyLen,
                             Arrays.toString(p))
                     );
@@ -213,9 +213,9 @@ public enum KeyType {
     /** Unrecognized */
     UNKNOWN("unknown") {
         @Override
-        public PublicKey readPubKeyFromBuffer(String type, Buffer<?> buf)
+        public PublicKey readPubKeyFromBuffer(Buffer<?> buf)
                 throws GeneralSecurityException {
-            throw new UnsupportedOperationException("Don't know how to decode key:" + type);
+            throw new UnsupportedOperationException("Don't know how to decode key:" + sType);
         }
 
         @Override
@@ -238,7 +238,7 @@ public enum KeyType {
         this.sType = type;
     }
 
-    public abstract PublicKey readPubKeyFromBuffer(String type, Buffer<?> buf)
+    public abstract PublicKey readPubKeyFromBuffer(Buffer<?> buf)
             throws GeneralSecurityException;
 
     public abstract void putPubKeyIntoBuffer(PublicKey pk, Buffer<?> buf);
@@ -263,5 +263,4 @@ public enum KeyType {
     public String toString() {
         return sType;
     }
-
 }

--- a/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
@@ -207,7 +207,7 @@ public class OpenSSHKnownHosts
 
             if (type != KeyType.UNKNOWN) {
                 final String sKey = split[i++];
-                key = getKey(sKey);
+                key = new Buffer.PlainBuffer(Base64.decode(sKey)).readPublicKey();
             } else if (isBits(sType)) {
                 type = KeyType.RSA;
                 // int bits = Integer.valueOf(sType);
@@ -230,11 +230,6 @@ public class OpenSSHKnownHosts
             } else {
                 return new SimpleEntry(marker, hostnames, type, key);
             }
-        }
-
-        private PublicKey getKey(String sKey)
-                throws IOException {
-            return new Buffer.PlainBuffer(Base64.decode(sKey)).readPublicKey();
         }
 
         private boolean isBits(String type) {

--- a/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
@@ -57,7 +57,7 @@ public class OpenSSHKnownHosts
             try {
                 // Read in the file, storing each line as an entry
                 String line;
-                while ((line = br.readLine()) != null)
+                while ((line = br.readLine()) != null) {
                     try {
                         HostEntry entry = entryFactory.parseEntry(line);
                         if (entry != null) {
@@ -65,7 +65,10 @@ public class OpenSSHKnownHosts
                         }
                     } catch (SSHException ignore) {
                         log.debug("Bad line ({}): {} ", ignore.toString(), line);
+                    } catch (SSHRuntimeException ignore) {
+                        log.debug("Failed to process line ({}): {} ", ignore.toString(), line);
                     }
+                }
             } finally {
                 IOUtils.closeQuietly(br);
             }

--- a/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS5KeyFile.java
+++ b/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS5KeyFile.java
@@ -194,31 +194,31 @@ public class PKCS5KeyFile
                 throw new FormatException("PKCS5 header not found");
             }
             ASN1Data asn = new ASN1Data(data = decrypt(Base64.decode(sb.toString()), cipher, iv));
-            switch(type) {
-              case RSA: {
-                KeyFactory factory = KeyFactory.getInstance("RSA");
-                asn.readNext();
-                BigInteger modulus = asn.readNext();
-                BigInteger pubExp = asn.readNext();
-                BigInteger prvExp = asn.readNext();
-                PublicKey pubKey = factory.generatePublic(new RSAPublicKeySpec(modulus, pubExp));
-                PrivateKey prvKey = factory.generatePrivate(new RSAPrivateKeySpec(modulus, prvExp));
-                return new KeyPair(pubKey, prvKey);
-              }
-              case DSA: {
-                KeyFactory factory = KeyFactory.getInstance("DSA");
-                asn.readNext();
-                BigInteger p = asn.readNext();
-                BigInteger q = asn.readNext();
-                BigInteger g = asn.readNext();
-                BigInteger pub = asn.readNext();
-                BigInteger prv = asn.readNext();
-                PublicKey pubKey = factory.generatePublic(new DSAPublicKeySpec(pub, p, q, g));
-                PrivateKey prvKey = factory.generatePrivate(new DSAPrivateKeySpec(prv, p, q, g));
-                return new KeyPair(pubKey, prvKey);
-              }
-              default:
-                throw new IOException("Unrecognized PKCS5 key type: " + type);
+            switch (type) {
+                case RSA: {
+                    KeyFactory factory = KeyFactory.getInstance("RSA");
+                    asn.readNext();
+                    BigInteger modulus = asn.readNext();
+                    BigInteger pubExp = asn.readNext();
+                    BigInteger prvExp = asn.readNext();
+                    PublicKey pubKey = factory.generatePublic(new RSAPublicKeySpec(modulus, pubExp));
+                    PrivateKey prvKey = factory.generatePrivate(new RSAPrivateKeySpec(modulus, prvExp));
+                    return new KeyPair(pubKey, prvKey);
+                }
+                case DSA: {
+                    KeyFactory factory = KeyFactory.getInstance("DSA");
+                    asn.readNext();
+                    BigInteger p = asn.readNext();
+                    BigInteger q = asn.readNext();
+                    BigInteger g = asn.readNext();
+                    BigInteger pub = asn.readNext();
+                    BigInteger prv = asn.readNext();
+                    PublicKey pubKey = factory.generatePublic(new DSAPublicKeySpec(pub, p, q, g));
+                    PrivateKey prvKey = factory.generatePrivate(new DSAPrivateKeySpec(prv, p, q, g));
+                    return new KeyPair(pubKey, prvKey);
+                }
+                default:
+                    throw new IOException("Unrecognized PKCS5 key type: " + type);
             }
         } catch (NoSuchAlgorithmException e) {
             throw new IOException(e);


### PR DESCRIPTION
If BouncyCastle is not present, I want to be able to load whatever bits of the known_hosts file I can (i.e., the ssh-dss and ssh-rsa keys).

While making this change I noticed the KeyType.readPubKeyFromBuffer method didn't require passing in the String type name, so I cleaned that up too.