### PR TITLE
Catch interrupt signal in keepalive thread

### DIFF
--- a/src/main/java/net/schmizz/keepalive/KeepAlive.java
+++ b/src/main/java/net/schmizz/keepalive/KeepAlive.java
@@ -65,6 +65,8 @@ public abstract class KeepAlive extends Thread {
                 }
                 Thread.sleep(hi * 1000);
             }
+        } catch (InterruptedException e) {
+            // Interrupt signal may be catched when sleeping.      
         } catch (Exception e) {
             // If we weren't interrupted, kill the transport, then this exception was unexpected.
             // Else we're in shutdown-mode already, so don't forcibly kill the transport.


### PR DESCRIPTION
Interrupt signal may be catched when keepalive thread is sleeping. It will still go into conn.getTransport().die(e) when we called keepalive.interrupt().