### PR TITLE
Two minor changes

### DIFF
--- a/src/main/java/net/schmizz/sshj/DefaultConfig.java
+++ b/src/main/java/net/schmizz/sshj/DefaultConfig.java
@@ -85,7 +85,7 @@ public class DefaultConfig
     private String readVersionFromProperties() {
         try {
             Properties properties = new Properties();
-            properties.load(Thread.currentThread().getContextClassLoader().getResourceAsStream("sshj.properties"));
+            properties.load(DefaultConfig.class.getClassLoader().getResourceAsStream("sshj.properties"));
             String property = properties.getProperty("sshj.version");
             return "SSHJ_" + property.replace('-', '_'); // '-' is a disallowed character, see RFC-4253#section-4.2
         } catch (IOException e) {

--- a/src/main/java/net/schmizz/sshj/common/SSHRuntimeException.java
+++ b/src/main/java/net/schmizz/sshj/common/SSHRuntimeException.java
@@ -34,7 +34,7 @@ public class SSHRuntimeException
     }
 
     public SSHRuntimeException(Throwable cause) {
-        this(null, cause);
+        this(cause.getMessage(), cause);
     }
 
 }


### PR DESCRIPTION
1) We shouldn't assume that the current thread context ClassLoader has access to the sshj.properties file, but it's safe to assume that the DefaultConfig class's ClassLoader does.

2) When creating an SSHRuntimeException based on a Throwable, I believe the SSHRuntimeException should adopt the message of the Throwable cause (instead of always using null).

WDYT?