### PR TITLE
excludes net.i2p.crypto.eddsa.math from OSGI Import-Package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ jar {
     instruction "Bundle-License", "http://www.apache.org/licenses/LICENSE-2.0.txt"
     instruction "Import-Package", "!net.schmizz.*"
     instruction "Import-Package", "javax.crypto*"
+    instruction "Import-Package", "!net.i2p.crypto.eddsa.math"
     instruction "Import-Package", "net.i2p*"
     instruction "Import-Package", "com.jcraft.jzlib*;version=\"[1.1,2)\";resolution:=optional"
     instruction "Import-Package", "org.slf4j*;version=\"[1.7,5)\""


### PR DESCRIPTION
This completes the work to correct bug #255.

The dependency was removed from the code, but the MANIFEST.MF file still had a reference to the private package.