### PR TITLE
Reference the EdDSANamedCurveTable constant instead of its value...

### DIFF
--- a/src/main/java/net/schmizz/sshj/common/KeyType.java
+++ b/src/main/java/net/schmizz/sshj/common/KeyType.java
@@ -192,7 +192,7 @@ public enum KeyType {
                     );
                 }
 
-                EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName("ed25519-sha-512");
+                EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.CURVE_ED25519_SHA512);
                 EdDSAPublicKeySpec publicSpec = new EdDSAPublicKeySpec(p, ed25519);
                 return new Ed25519PublicKey(publicSpec);
 


### PR DESCRIPTION
For forward-compatibility with the ed25519-java project on Github.

See: https://github.com/str4d/ed25519-java/commit/abdee146c302e2e26976519de8b6413079960171