### PR TITLE
Disambiguated signature initialization

### DIFF
--- a/src/main/java/com/hierynomus/sshj/signature/SignatureEdDSA.java
+++ b/src/main/java/com/hierynomus/sshj/signature/SignatureEdDSA.java
@@ -48,21 +48,6 @@ public class SignatureEdDSA implements Signature {
     }
 
     @Override
-    public void init(PublicKey pubkey, PrivateKey prvkey) {
-        try {
-            if (pubkey != null) {
-                engine.initVerify(pubkey);
-            }
-
-            if (prvkey != null) {
-                engine.initSign(prvkey);
-            }
-        } catch (InvalidKeyException e) {
-            throw new SSHRuntimeException(e);
-        }
-    }
-
-    @Override
     public void initVerify(PublicKey pubkey) {
         try {
             engine.initVerify(pubkey);

--- a/src/main/java/com/hierynomus/sshj/signature/SignatureEdDSA.java
+++ b/src/main/java/com/hierynomus/sshj/signature/SignatureEdDSA.java
@@ -63,6 +63,24 @@ public class SignatureEdDSA implements Signature {
     }
 
     @Override
+    public void initVerify(PublicKey pubkey) {
+        try {
+            engine.initVerify(pubkey);
+        } catch (InvalidKeyException e) {
+            throw new SSHRuntimeException(e);
+        }
+    }
+
+    @Override
+    public void initSign(PrivateKey prvkey) {
+        try {
+            engine.initSign(prvkey);
+        } catch (InvalidKeyException e) {
+            throw new SSHRuntimeException(e);
+        }
+    }
+
+    @Override
     public void update(byte[] H) {
         update(H, 0, H.length);
     }

--- a/src/main/java/net/schmizz/sshj/signature/AbstractSignature.java
+++ b/src/main/java/net/schmizz/sshj/signature/AbstractSignature.java
@@ -35,19 +35,6 @@ public abstract class AbstractSignature
     }
 
     @Override
-    public void init(PublicKey publicKey, PrivateKey privateKey) {
-        try {
-            signature = SecurityUtils.getSignature(algorithm);
-            if (publicKey != null)
-                signature.initVerify(publicKey);
-            if (privateKey != null)
-                signature.initSign(privateKey);
-        } catch (GeneralSecurityException e) {
-            throw new SSHRuntimeException(e);
-        }
-    }
-
-    @Override
     public void initVerify(PublicKey publicKey) {
         try {
             signature = SecurityUtils.getSignature(algorithm);

--- a/src/main/java/net/schmizz/sshj/signature/AbstractSignature.java
+++ b/src/main/java/net/schmizz/sshj/signature/AbstractSignature.java
@@ -48,6 +48,26 @@ public abstract class AbstractSignature
     }
 
     @Override
+    public void initVerify(PublicKey publicKey) {
+        try {
+            signature = SecurityUtils.getSignature(algorithm);
+            signature.initVerify(publicKey);
+        } catch (GeneralSecurityException e) {
+            throw new SSHRuntimeException(e);
+        }
+    }
+
+    @Override
+    public void initSign(PrivateKey privateKey) {
+        try {
+            signature = SecurityUtils.getSignature(algorithm);
+            signature.initSign(privateKey);
+        } catch (GeneralSecurityException e) {
+            throw new SSHRuntimeException(e);
+        }
+    }
+
+    @Override
     public void update(byte[] foo) {
         update(foo, 0, foo.length);
     }

--- a/src/main/java/net/schmizz/sshj/signature/Signature.java
+++ b/src/main/java/net/schmizz/sshj/signature/Signature.java
@@ -22,17 +22,6 @@ import java.security.PublicKey;
 public interface Signature {
 
     /**
-     * Initialize this signature with the given public key and private key. If the private key is null, only signature
-     * verification can be performed.
-     *
-     * @param pubkey (null-ok) specify in case verification is needed
-     * @param prvkey (null-ok) specify in case signing is needed
-     * @deprecated Use {@link #initVerify(PublicKey)} or {@link #initSign(PrivateKey)} instead.
-     */
-    @Deprecated
-    void init(PublicKey pubkey, PrivateKey prvkey);
-
-    /**
      * Initialize this signature with the given public key for signature verification.
      *
      * Note that subsequent calls to either {@link #initVerify(PublicKey)} or {@link #initSign(PrivateKey)} will

--- a/src/main/java/net/schmizz/sshj/signature/Signature.java
+++ b/src/main/java/net/schmizz/sshj/signature/Signature.java
@@ -27,8 +27,30 @@ public interface Signature {
      *
      * @param pubkey (null-ok) specify in case verification is needed
      * @param prvkey (null-ok) specify in case signing is needed
+     * @deprecated Use {@link #initVerify(PublicKey)} or {@link #initSign(PrivateKey)} instead.
      */
+    @Deprecated
     void init(PublicKey pubkey, PrivateKey prvkey);
+
+    /**
+     * Initialize this signature with the given public key for signature verification.
+     *
+     * Note that subsequent calls to either {@link #initVerify(PublicKey)} or {@link #initSign(PrivateKey)} will
+     * overwrite prior initialization.
+     *
+     * @param pubkey the public key to use for signature verification
+     */
+    void initVerify(PublicKey pubkey);
+
+    /**
+     * Initialize this signature with the given private key for signing.
+     *
+     * Note that subsequent calls to either {@link #initVerify(PublicKey)} or {@link #initSign(PrivateKey)} will
+     * overwrite prior initialization.
+     *
+     * @param prvkey the private key to use for signing
+     */
+    void initSign(PrivateKey prvkey);
 
     /**
      * Convenience method, same as calling {@link #update(byte[], int, int)} with offset as {@code 0} and {@code

--- a/src/main/java/net/schmizz/sshj/transport/kex/AbstractDHG.java
+++ b/src/main/java/net/schmizz/sshj/transport/kex/AbstractDHG.java
@@ -80,7 +80,7 @@ public abstract class AbstractDHG extends AbstractDH
 
         Signature signature = Factory.Named.Util.create(trans.getConfig().getSignatureFactories(),
                                                         KeyType.fromKey(hostKey).toString());
-        signature.init(hostKey, null);
+        signature.initVerify(hostKey);
         signature.update(H, 0, H.length);
         if (!signature.verify(sig))
             throw new TransportException(DisconnectReason.KEY_EXCHANGE_FAILED,

--- a/src/main/java/net/schmizz/sshj/transport/kex/AbstractDHGex.java
+++ b/src/main/java/net/schmizz/sshj/transport/kex/AbstractDHGex.java
@@ -86,7 +86,7 @@ public abstract class AbstractDHGex extends AbstractDH {
         H = digest.digest();
         Signature signature = Factory.Named.Util.create(trans.getConfig().getSignatureFactories(),
                 KeyType.fromKey(hostKey).toString());
-        signature.init(hostKey, null);
+        signature.initVerify(hostKey);
         signature.update(H, 0, H.length);
         if (!signature.verify(sig))
             throw new TransportException(DisconnectReason.KEY_EXCHANGE_FAILED,

--- a/src/main/java/net/schmizz/sshj/userauth/method/KeyedAuthMethod.java
+++ b/src/main/java/net/schmizz/sshj/userauth/method/KeyedAuthMethod.java
@@ -66,7 +66,7 @@ public abstract class KeyedAuthMethod
         if (signature == null)
             throw new UserAuthException("Could not create signature instance for " + kt + " key");
 
-        signature.init(null, key);
+        signature.initSign(key);
         signature.update(new Buffer.PlainBuffer()
                 .putString(params.getTransport().getSessionID())
                 .putBuffer(reqBuf) // & rest of the data for sig

--- a/src/test/java/net/schmizz/sshj/signature/VerificationTest.java
+++ b/src/test/java/net/schmizz/sshj/signature/VerificationTest.java
@@ -34,7 +34,7 @@ public class VerificationTest {
         PublicKey hostKey = new Buffer.PlainBuffer(K_S).readPublicKey();
 
         Signature signature = new SignatureECDSA.Factory256().create();
-        signature.init(hostKey, null);
+        signature.initVerify(hostKey);
         signature.update(H, 0, H.length);
         
         Assert.assertTrue("ECDSA256 signature verifies", signature.verify(sig));
@@ -49,7 +49,7 @@ public class VerificationTest {
         PublicKey hostKey = new Buffer.PlainBuffer(K_S).readPublicKey();
 
         Signature signature = new SignatureECDSA.Factory384().create();
-        signature.init(hostKey, null);
+        signature.initVerify(hostKey);
         signature.update(H, 0, H.length);
         
         Assert.assertTrue("ECDSA384 signature verifies", signature.verify(sig));
@@ -64,7 +64,7 @@ public class VerificationTest {
         PublicKey hostKey = new Buffer.PlainBuffer(K_S).readPublicKey();
 
         Signature signature = new SignatureECDSA.Factory521().create();
-        signature.init(hostKey, null);
+        signature.initVerify(hostKey);
         signature.update(H, 0, H.length);
         
         Assert.assertTrue("ECDSA521 signature verifies", signature.verify(sig));


### PR DESCRIPTION
Initially (hah), the signature API was slightly unclear in that if you called `Signature#initialize(PublicKey, PrivateKey)` with non-null `publicKey` and `privateKey`, the underlying `Signature` would only be initialized for signing, and not verification.