### PR TITLE
Log security provider registration failures

### DIFF
--- a/src/main/java/net/schmizz/sshj/common/SecurityUtils.java
+++ b/src/main/java/net/schmizz/sshj/common/SecurityUtils.java
@@ -69,15 +69,15 @@ public class SecurityUtils {
             }
 
             if (securityProvider == null) {
-                MessageDigest.getInstance("MD5", provider.getName());
-                KeyAgreement.getInstance("DH", provider.getName());
+                MessageDigest.getInstance("MD5", provider);
+                KeyAgreement.getInstance("DH", provider);
                 setSecurityProvider(provider.getName());
                 return true;
             }
         } catch (NoSuchAlgorithmException e) {
             LOG.info(format("Security Provider '%s' does not support necessary algorithm", providerClassName), e);
-        } catch (NoSuchProviderException e) {
-            LOG.info("Registration of Security Provider '{}' unexpectedly failed", providerClassName);
+        } catch (Exception e) {
+            LOG.info(format("Registration of Security Provider '%s' unexpectedly failed", providerClassName), e);
         }
         return false;
     }


### PR DESCRIPTION
On my servers, BouncyCastle was failing to register because the `java.security` file listed DSA as a disabled algorithm (no matter the keysize). It wasn't clear from the logs that the problem was that the BouncyCastle jar was signed using DSA.

```
INFO [net.schmizz.sshj.common.SecurityUtils] Registration of Security Provider 'org.bouncycastle.jce.provider.BouncyCastleProvider' unexpectedly failed
INFO [net.schmizz.sshj.common.SecurityUtils] BouncyCastle not registered, using the default JCE provider
```

By logging the root cause, it's much easier to identify and fix the problem.

```
INFO [net.schmizz.sshj.common.SecurityUtils] Registration of Security Provider 'org.bouncycastle.jce.provider.BouncyCastleProvider' unexpectedly failed
java.lang.SecurityException: JCE cannot authenticate the provider BC
	at javax.crypto.JceSecurity.getInstance(JceSecurity.java:113)
	at javax.crypto.KeyAgreement.getInstance(KeyAgreement.java:270)
	at net.schmizz.sshj.common.SecurityUtils.registerSecurityProvider(SecurityUtils.java:73)
	at net.schmizz.sshj.common.SecurityUtils.register(SecurityUtils.java:250)
	at net.schmizz.sshj.common.SecurityUtils.isBouncyCastleRegistered(SecurityUtils.java:228)
	at net.schmizz.sshj.DefaultConfig.<init>(DefaultConfig.java:78)
	at net.schmizz.sshj.SSHClient.<init>(SSHClient.java:134)
	...
Caused by: java.util.jar.JarException: file:/path/to/org.bouncycastle.bcprov-jdk15on-1.56.jar is not signed by a trusted signer.
	at javax.crypto.JarVerifier.verifySingleJar(JarVerifier.java:538)
	at javax.crypto.JarVerifier.verifyJars(JarVerifier.java:361)
	at javax.crypto.JarVerifier.verify(JarVerifier.java:289)
	at javax.crypto.JceSecurity.verifyProviderJar(JceSecurity.java:159)
	at javax.crypto.JceSecurity.getVerificationResult(JceSecurity.java:185)
	at javax.crypto.JceSecurity.getInstance(JceSecurity.java:109)
	... 37 common frames omitted
INFO [net.schmizz.sshj.common.SecurityUtils] BouncyCastle not registered, using the default JCE provider
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting CAST5/CBC/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting CAST5/CTR/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting IDEA/CBC/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting IDEA/CTR/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Serpent/CBC/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Serpent/CTR/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Serpent/CBC/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Serpent/CTR/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Serpent/CBC/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Serpent/CTR/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Twofish/CBC/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Twofish/CTR/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Twofish/CBC/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Twofish/CTR/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Twofish/CBC/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Twofish/CTR/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Cannot find any provider supporting Twofish/CBC/NoPadding
WARN [net.schmizz.sshj.DefaultConfig       ] Disabling high-strength ciphers: cipher strengths apparently limited by JCE policy
```

FWIW, I fixed my problem by changing

```
jdk.certpath.disabledAlgorithms=DSA, ... (other disabled algorithms)
```
to 

```
jdk.certpath.disabledAlgorithms=DSA keySize < 1024, ... (other disabled algorithms)
```