### PR TITLE
Android Compability, again ;-) 

### DIFF
--- a/src/main/java/net/schmizz/sshj/AndroidConfig.java
+++ b/src/main/java/net/schmizz/sshj/AndroidConfig.java
@@ -19,22 +19,19 @@ import com.hierynomus.sshj.signature.SignatureEdDSA;
 
 import net.schmizz.sshj.common.SecurityUtils;
 import net.schmizz.sshj.signature.SignatureDSA;
+import net.schmizz.sshj.signature.SignatureECDSA;
 import net.schmizz.sshj.signature.SignatureRSA;
 import net.schmizz.sshj.transport.random.JCERandom;
 import net.schmizz.sshj.transport.random.SingletonRandomFactory;
 
+/**
+ * Registers SpongyCastle as JCE provider.
+ */
 public class AndroidConfig
         extends DefaultConfig {
 
     static {
-        SecurityUtils.registerSecurityProvider("org.spongycastle.jce.provider.BouncyCastleProvider");
-    }
-
-    public AndroidConfig(){
-        super();
-        initKeyExchangeFactories(true);
-        initRandomFactory(true);
-        initFileKeyProviderFactories(true);
+        SecurityUtils.registerSecurityProvider(SecurityUtils.SPONGY_CASTLE, "org.spongycastle.jce.provider.BouncyCastleProvider");
     }
 
     // don't add ECDSA

--- a/src/main/java/net/schmizz/sshj/AndroidConfig.java
+++ b/src/main/java/net/schmizz/sshj/AndroidConfig.java
@@ -19,7 +19,6 @@ import com.hierynomus.sshj.signature.SignatureEdDSA;
 
 import net.schmizz.sshj.common.SecurityUtils;
 import net.schmizz.sshj.signature.SignatureDSA;
-import net.schmizz.sshj.signature.SignatureECDSA;
 import net.schmizz.sshj.signature.SignatureRSA;
 import net.schmizz.sshj.transport.random.JCERandom;
 import net.schmizz.sshj.transport.random.SingletonRandomFactory;
@@ -31,7 +30,7 @@ public class AndroidConfig
         extends DefaultConfig {
 
     static {
-        SecurityUtils.registerSecurityProvider(SecurityUtils.SPONGY_CASTLE, "org.spongycastle.jce.provider.BouncyCastleProvider");
+        SecurityUtils.registerSecurityProvider("org.spongycastle.jce.provider.BouncyCastleProvider");
     }
 
     // don't add ECDSA

--- a/src/main/java/net/schmizz/sshj/DefaultConfig.java
+++ b/src/main/java/net/schmizz/sshj/DefaultConfig.java
@@ -92,7 +92,7 @@ public class DefaultConfig
             properties.load(DefaultConfig.class.getClassLoader().getResourceAsStream("sshj.properties"));
             String property = properties.getProperty("sshj.version");
             return "SSHJ_" + property.replace('-', '_'); // '-' is a disallowed character, see RFC-4253#section-4.2
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.error("Could not read the sshj.properties file, returning an 'unknown' version as fallback.");
             return "SSHJ_VERSION_UNKNOWN";
         }

--- a/src/main/java/net/schmizz/sshj/common/SecurityUtils.java
+++ b/src/main/java/net/schmizz/sshj/common/SecurityUtils.java
@@ -51,7 +51,7 @@ public class SecurityUtils {
     private static Boolean registerBouncyCastle;
     private static boolean registrationDone;
 
-    public static boolean registerSecurityProvider(String providerIdentifier, String providerClassName) {
+    public static boolean registerSecurityProvider(String providerClassName) {
         Provider provider = null;
         try {
             Class<?> name = Class.forName(providerClassName);
@@ -86,6 +86,8 @@ public class SecurityUtils {
         }
         return false;
     }
+
+
 
     public static synchronized Cipher getCipher(String transformation)
             throws NoSuchAlgorithmException, NoSuchPaddingException, NoSuchProviderException {
@@ -252,7 +254,7 @@ public class SecurityUtils {
     private static void register() {
         if (!registrationDone) {
             if (securityProvider == null && (registerBouncyCastle == null || registerBouncyCastle)) {
-                registerSecurityProvider(BOUNCY_CASTLE, "org.bouncycastle.jce.provider.BouncyCastleProvider");
+                registerSecurityProvider("org.bouncycastle.jce.provider.BouncyCastleProvider");
                 if (securityProvider == null && registerBouncyCastle == null) {
                     LOG.info("BouncyCastle not registered, using the default JCE provider");
                 } else if (securityProvider == null) {

--- a/src/main/java/net/schmizz/sshj/common/SecurityUtils.java
+++ b/src/main/java/net/schmizz/sshj/common/SecurityUtils.java
@@ -18,11 +18,21 @@ package net.schmizz.sshj.common;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.Signature;
+
 import javax.crypto.Cipher;
 import javax.crypto.KeyAgreement;
 import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
-import java.security.*;
 
 import static java.lang.String.format;
 

--- a/src/main/java/net/schmizz/sshj/common/SecurityUtils.java
+++ b/src/main/java/net/schmizz/sshj/common/SecurityUtils.java
@@ -37,16 +37,21 @@ public class SecurityUtils {
      */
     public static final String BOUNCY_CASTLE = "BC";
 
+    /**
+     * Identifier for the BouncyCastle JCE provider
+     */
+    public static final String SPONGY_CASTLE = "SC";
+
     /*
     * Security provider identifier. null = default JCE
     */
     private static String securityProvider = null;
 
-    // relate to BC registration
+    // relate to BC registration (or SpongyCastle on Android)
     private static Boolean registerBouncyCastle;
     private static boolean registrationDone;
 
-    public static boolean registerSecurityProvider(String providerClassName) {
+    public static boolean registerSecurityProvider(String providerIdentifier, String providerClassName) {
         Provider provider = null;
         try {
             Class<?> name = Class.forName(providerClassName);
@@ -222,11 +227,11 @@ public class SecurityUtils {
      * Attempts registering BouncyCastle as security provider if it has not been previously attempted and returns
      * whether the registration succeeded.
      *
-     * @return whether BC registered
+     * @return whether BC (or SC on Android) registered
      */
     public static synchronized boolean isBouncyCastleRegistered() {
         register();
-        return BOUNCY_CASTLE.equals(securityProvider);
+        return BOUNCY_CASTLE.equals(securityProvider) || SPONGY_CASTLE.equals(securityProvider);
     }
 
     public static synchronized void setRegisterBouncyCastle(boolean registerBouncyCastle) {
@@ -247,7 +252,7 @@ public class SecurityUtils {
     private static void register() {
         if (!registrationDone) {
             if (securityProvider == null && (registerBouncyCastle == null || registerBouncyCastle)) {
-                registerSecurityProvider("org.bouncycastle.jce.provider.BouncyCastleProvider");
+                registerSecurityProvider(BOUNCY_CASTLE, "org.bouncycastle.jce.provider.BouncyCastleProvider");
                 if (securityProvider == null && registerBouncyCastle == null) {
                     LOG.info("BouncyCastle not registered, using the default JCE provider");
                 } else if (securityProvider == null) {

--- a/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS8KeyFile.java
+++ b/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS8KeyFile.java
@@ -16,6 +16,7 @@
 package net.schmizz.sshj.userauth.keyprovider;
 
 import net.schmizz.sshj.common.IOUtils;
+import net.schmizz.sshj.common.SecurityUtils;
 import net.schmizz.sshj.userauth.password.PasswordUtils;
 import org.bouncycastle.openssl.EncryptionException;
 import org.bouncycastle.openssl.PEMEncryptedKeyPair;
@@ -62,12 +63,12 @@ public class PKCS8KeyFile extends BaseFileKeyProvider {
                 final Object o = r.readObject();
 
                 final JcaPEMKeyConverter pemConverter = new JcaPEMKeyConverter();
-                pemConverter.setProvider("BC");
+                pemConverter.setProvider(SecurityUtils.getSecurityProvider());
 
                 if (o instanceof PEMEncryptedKeyPair) {
                     final PEMEncryptedKeyPair encryptedKeyPair = (PEMEncryptedKeyPair) o;
                     JcePEMDecryptorProviderBuilder decryptorBuilder = new JcePEMDecryptorProviderBuilder();
-                    decryptorBuilder.setProvider("BC");
+                    decryptorBuilder.setProvider(SecurityUtils.getSecurityProvider());
                     try {
                         passphrase = pwdf == null ? null : pwdf.reqPassword(resource);
                         kp = pemConverter.getKeyPair(encryptedKeyPair.decryptKeyPair(decryptorBuilder.build(passphrase)));


### PR DESCRIPTION
As mentioned in https://github.com/hierynomus/sshj/issues/308#issuecomment-288636517, PCKS8KeyFile had a hard dependency on BouncyCastle as JCE provider.

In combination with SpongyCastle on Android an the updated AndroidConfig, this leads to exceptions when running on Android and using publickey auth (excerpt from my Android app):
```
21:18:17.060 [AsyncTask #5] ERROR net.schmizz.concurrent.Promise - <<authenticated>> woke to: net.schmizz.sshj.userauth.UserAuthException: Problem getting private key from PKCS8KeyFile{resource=[PrivateKeyFileResource] /storage/emulated/0/ssh/ID_Andromeda}
21:18:17.067 [AsyncTask #5] INFO  d.e.rpicheck.ssh.impl.RaspiQuery - Authentification failed.
net.schmizz.sshj.userauth.UserAuthException: Exhausted available authentication methods
	at net.schmizz.sshj.SSHClient.auth(SSHClient.java:231) ~[na:0.0]
	at net.schmizz.sshj.SSHClient.authPublickey(SSHClient.java:346) ~[na:0.0]
	at net.schmizz.sshj.SSHClient.authPublickey(SSHClient.java:365) ~[na:0.0]
	at de.eidottermihi.rpicheck.ssh.impl.RaspiQuery.connectWithPubKeyAuthAndPassphrase(RaspiQuery.java:1167) ~[na:0.0]
	at de.eidottermihi.rpicheck.activity.SSHQueryTask.doInBackground(SSHQueryTask.java:90) ~[na:0.0]
	at de.eidottermihi.rpicheck.activity.SSHQueryTask.doInBackground(SSHQueryTask.java:46) ~[na:0.0]
	at android.os.AsyncTask$2.call(AsyncTask.java:295) ~[na:0.0]
	at java.util.concurrent.FutureTask.run(FutureTask.java:237) ~[na:0.0]
	at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:234) ~[na:0.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113) ~[na:0.0]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588) ~[na:0.0]
	at java.lang.Thread.run(Thread.java:818) ~[na:0.0]
Caused by: net.schmizz.sshj.userauth.UserAuthException: Problem getting private key from PKCS8KeyFile{resource=[PrivateKeyFileResource] /storage/emulated/0/ssh/ID_Andromeda}
	at net.schmizz.sshj.userauth.method.KeyedAuthMethod.putSig(KeyedAuthMethod.java:61) ~[na:0.0]
	at net.schmizz.sshj.userauth.method.AuthPublickey.sendSignedReq(AuthPublickey.java:74) ~[na:0.0]
	at net.schmizz.sshj.userauth.method.AuthPublickey.handle(AuthPublickey.java:45) ~[na:0.0]
	at net.schmizz.sshj.userauth.UserAuthImpl.handle(UserAuthImpl.java:142) ~[na:0.0]
	at net.schmizz.sshj.transport.TransportImpl.handle(TransportImpl.java:500) ~[na:0.0]
	at net.schmizz.sshj.transport.Decoder.decode(Decoder.java:102) ~[na:0.0]
	at net.schmizz.sshj.transport.Decoder.received(Decoder.java:170) ~[na:0.0]
	at net.schmizz.sshj.transport.Reader.run(Reader.java:59) ~[na:0.0]
Caused by: org.bouncycastle.openssl.PEMException: Unable to create OpenSSL PBDKF: BC
	at org.bouncycastle.openssl.jcajce.PEMUtilities.getKey(Unknown Source) ~[na:0.0]
	at org.bouncycastle.openssl.jcajce.PEMUtilities.getKey(Unknown Source) ~[na:0.0]
	at org.bouncycastle.openssl.jcajce.PEMUtilities.crypt(Unknown Source) ~[na:0.0]
	at org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder$1$1.decrypt(Unknown Source) ~[na:0.0]
	at org.bouncycastle.openssl.PEMEncryptedKeyPair.decryptKeyPair(Unknown Source) ~[na:0.0]
	at net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile.readKeyPair(PKCS8KeyFile.java:73) ~[na:0.0]
	at net.schmizz.sshj.userauth.keyprovider.BaseFileKeyProvider.getPrivate(BaseFileKeyProvider.java:75) ~[na:0.0]
	at net.schmizz.sshj.userauth.method.KeyedAuthMethod.putSig(KeyedAuthMethod.java:59) ~[na:0.0]
	... 7 common frames omitted
Caused by: java.security.NoSuchProviderException: BC
	at javax.crypto.SecretKeyFactory.getInstance(SecretKeyFactory.java:139) ~[na:0.0]
	at org.bouncycastle.jcajce.util.NamedJcaJceHelper.createSecretKeyFactory(Unknown Source) ~[na:0.0]
	... 15 common frames omitted
```
With these changes PKCS8KeyFile relies on the previously registered JCE provider (which could be BC __or__ SC).
Furthermore, AndroidConfig is now much simpler (no more dirty workarounds for _isBouncyCastleRegistered()_ as this method now returns true when SpongyCastle was registered).