### PR TITLE
HostEntry constructor must be public

### DIFF
--- a/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
@@ -310,7 +310,7 @@ public class OpenSSHKnownHosts
         protected final PublicKey key;
         private final KnownHostMatchers.HostMatcher matcher;
 
-        HostEntry(Marker marker, String hostPart, KeyType type, PublicKey key) throws SSHException {
+        public HostEntry(Marker marker, String hostPart, KeyType type, PublicKey key) throws SSHException {
             this.marker = marker;
             this.hostPart = hostPart;
             this.type = type;


### PR DESCRIPTION
Reasons:

1) SimpleEntry (was replaced to HostEntry) class had public constructor
2) HostEntry class can be used outside of sshj library to add entries to .known_hosts file (i.e. for implementation of interactive HostKeyVerifier)