### PR TITLE
add Buffer capacity check for type UInt64

### DIFF
--- a/src/main/java/net/schmizz/sshj/common/Buffer.java
+++ b/src/main/java/net/schmizz/sshj/common/Buffer.java
@@ -372,6 +372,7 @@ public class Buffer<T extends Buffer<T>> {
 
     @SuppressWarnings("unchecked")
     private T putUInt64Unchecked(long uint64) {
+        ensureCapacity(8);
         data[wpos++] = (byte) (uint64 >> 56);
         data[wpos++] = (byte) (uint64 >> 48);
         data[wpos++] = (byte) (uint64 >> 40);

--- a/src/test/java/net/schmizz/sshj/common/BufferTest.java
+++ b/src/test/java/net/schmizz/sshj/common/BufferTest.java
@@ -146,4 +146,28 @@ public class BufferTest {
             assertArrayEquals("Value: " + value, bytesLong, bytesBigInt);
         }
     }
+
+
+    @Test
+    public void shouldExpandCapacityOfUInt32(){
+        PlainBuffer buf = new PlainBuffer();
+        for(int i=0;i<Buffer.DEFAULT_SIZE+1;i+=4) {
+            buf.putUInt32(1l);
+        }
+        /* Buffer should have been expanded at this point*/
+        assertEquals(Buffer.DEFAULT_SIZE*2,buf.data.length);
+    }
+
+    @Test
+    public void shouldExpandCapacityOfUInt64(){
+        BigInteger bigUint64 = BigInteger.valueOf(Long.MAX_VALUE);
+        PlainBuffer buf = new PlainBuffer();
+        assertEquals(Buffer.DEFAULT_SIZE,buf.data.length);
+        for(int i=0;i<Buffer.DEFAULT_SIZE+1;i+=8) {
+            buf.putUInt64(bigUint64.longValue());
+        }
+        /* Buffer should have been expanded at this point*/
+        assertEquals(Buffer.DEFAULT_SIZE*2,buf.data.length);
+    }
+
 }


### PR DESCRIPTION
While working with openssh signed certificate of type **ssh-rsa-cert-v01@openssh.com** , i encountered the following exception \:

```
java.lang.ArrayIndexOutOfBoundsException: 514
	at net.schmizz.sshj.common.Buffer.putUInt64Unchecked(Buffer.java:375)
	at net.schmizz.sshj.common.Buffer.putUInt64(Buffer.java:362)
	at net.schmizz.sshj.common.KeyType$CertUtils.writePubKeyContentsIntoBuffer(KeyType.java:340)
	at net.schmizz.sshj.common.KeyType$7.writePubKeyContentsIntoBuffer(KeyType.java:217)
	at net.schmizz.sshj.common.KeyType.putPubKeyIntoBuffer(KeyType.java:281)
	at net.schmizz.sshj.common.Buffer.putPublicKey(Buffer.java:477)
	at net.schmizz.sshj.userauth.method.KeyedAuthMethod.putPubKey(KeyedAuthMethod.java:51)
	at net.schmizz.sshj.userauth.method.AuthPublickey.buildReq(AuthPublickey.java:62)
	at net.schmizz.sshj.userauth.method.AuthPublickey.buildReq(AuthPublickey.java:81)
	at net.schmizz.sshj.userauth.method.AbstractAuthMethod.request(AbstractAuthMethod.java:68)
	at net.schmizz.sshj.userauth.UserAuthImpl.authenticate(UserAuthImpl.java:72)
	at net.schmizz.sshj.SSHClient.auth(SSHClient.java:225)
	at net.schmizz.sshj.SSHClient.authPublickey(SSHClient.java:346)
	at net.schmizz.sshj.SSHClient.authPublickey(SSHClient.java:365)
```

The cause of the issue is in the class `net\schmizz\sshj\common\Buffer`. When a 64-bit Uint is put in the buffer, the capacity of the buffer is neither checked or expanded (as it is done for the other types).

I fixed the issue and have added 2 units tests.
