### PR TITLE
Improving logging for KeyExchanger

### DIFF
--- a/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
+++ b/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 final class KeyExchanger
         implements SSHPacketHandler, ErrorNotifiable {
 
-    private static enum Expected {
+    private enum Expected {
         /** we have sent or are sending KEXINIT, and expect the server's KEXINIT */
         KEXINIT,
         /** we are expecting some followup data as part of the exchange */

--- a/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
+++ b/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 final class KeyExchanger
         implements SSHPacketHandler, ErrorNotifiable {
 
-    private enum Expected {
+    private static enum Expected {
         /** we have sent or are sending KEXINIT, and expect the server's KEXINIT */
         KEXINIT,
         /** we are expecting some followup data as part of the exchange */

--- a/src/main/java/net/schmizz/sshj/transport/verification/FingerprintVerifier.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/FingerprintVerifier.java
@@ -26,7 +26,6 @@ import net.schmizz.sshj.common.Base64;
 import net.schmizz.sshj.common.Buffer;
 import net.schmizz.sshj.common.SSHRuntimeException;
 import net.schmizz.sshj.common.SecurityUtils;
-import net.schmizz.sshj.transport.verification.HostKeyVerifier;
 
 public class FingerprintVerifier implements HostKeyVerifier {
     private static final Pattern MD5_FINGERPRINT_PATTERN = Pattern.compile("[0-9a-f]{2}+(:[0-9a-f]{2}+){15}+");
@@ -121,4 +120,8 @@ public class FingerprintVerifier implements HostKeyVerifier {
         return Arrays.equals(fingerprintData, digestData);
     }
 
+    @Override
+    public String toString() {
+        return "FingerprintVerifier{digestAlgorithm='" + digestAlgorithm + "'}";
+    }
 }

--- a/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
@@ -443,14 +443,7 @@ public class OpenSSHKnownHosts
 
     @Override
     public String toString() {
-        final List<String> entriesList = new ArrayList<String>();
-        for (KnownHostEntry entry : entries) {
-            entriesList.add(entry.getLine());
-        }
-        return "OpenSSHKnownHosts{" +
-                "khFile=" + khFile +
-                ", entries=" + entriesList +
-                '}';
+        return "OpenSSHKnownHosts{khFile='" + khFile + "'}";
     }
 
 }

--- a/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
@@ -440,4 +440,17 @@ public class OpenSSHKnownHosts
             return null;
         }
     }
+
+    @Override
+    public String toString() {
+        final List<String> entriesList = new ArrayList<String>();
+        for (KnownHostEntry entry : entries) {
+            entriesList.add(entry.getLine());
+        }
+        return "OpenSSHKnownHosts{" +
+                "khFile=" + khFile +
+                ", entries=" + entriesList +
+                '}';
+    }
+
 }

--- a/src/test/groovy/com/hierynomus/sshj/transport/verification/OpenSSHKnownHostsSpec.groovy
+++ b/src/test/groovy/com/hierynomus/sshj/transport/verification/OpenSSHKnownHostsSpec.groovy
@@ -141,8 +141,7 @@ host1 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL
 
         def toStringValue = knownhosts.toString()
         then:
-        toStringValue.startsWith("OpenSSHKnownHosts{khFile=")
-        toStringValue.endsWith("entries=[schmizz.net,69.163.155.180 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6P9Hlwdahh250jGZYKg2snRq2j2lFJVdKSHyxqbJiVy9VX9gTkN3K2MD48qyrYLYOyGs3vTttyUk+cK++JMzURWsrP4piby7LpeOT+3Iq8CQNj4gXZdcH9w15Vuk2qS11at6IsQPVHpKD9HGg9//EFUccI/4w06k4XXLm/IxOGUwj6I2AeWmEOL3aDi+fe07TTosSdLUD6INtR0cyKsg0zC7Da24ixoShT8Oy3x2MpR7CY3PQ1pUVmvPkr79VeA+4qV9F1JM09WdboAMZgWQZ+XrbtuBlGsyhpUHSCQOya+kOJ+bYryS+U7A+6nmTW3C9FX4FgFqTF89UHOC7V0zZQ==]}")
+        toStringValue == "OpenSSHKnownHosts{khFile='" + f + "'}"
     }
 
     def knownHosts(String s) {

--- a/src/test/groovy/com/hierynomus/sshj/transport/verification/OpenSSHKnownHostsSpec.groovy
+++ b/src/test/groovy/com/hierynomus/sshj/transport/verification/OpenSSHKnownHostsSpec.groovy
@@ -132,6 +132,19 @@ host1 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL
         h << ["schmizz.net", "69.163.155.180"]
     }
 
+    def "should produce meaningful toString()"() {
+        given:
+        def f = knownHosts("schmizz.net,69.163.155.180 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6P9Hlwdahh250jGZYKg2snRq2j2lFJVdKSHyxqbJiVy9VX9gTkN3K2MD48qyrYLYOyGs3vTttyUk+cK++JMzURWsrP4piby7LpeOT+3Iq8CQNj4gXZdcH9w15Vuk2qS11at6IsQPVHpKD9HGg9//EFUccI/4w06k4XXLm/IxOGUwj6I2AeWmEOL3aDi+fe07TTosSdLUD6INtR0cyKsg0zC7Da24ixoShT8Oy3x2MpR7CY3PQ1pUVmvPkr79VeA+4qV9F1JM09WdboAMZgWQZ+XrbtuBlGsyhpUHSCQOya+kOJ+bYryS+U7A+6nmTW3C9FX4FgFqTF89UHOC7V0zZQ==")
+
+        when:
+        def knownhosts = new OpenSSHKnownHosts(f)
+
+        def toStringValue = knownhosts.toString()
+        then:
+        toStringValue.startsWith("OpenSSHKnownHosts{khFile=")
+        toStringValue.endsWith("entries=[schmizz.net,69.163.155.180 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6P9Hlwdahh250jGZYKg2snRq2j2lFJVdKSHyxqbJiVy9VX9gTkN3K2MD48qyrYLYOyGs3vTttyUk+cK++JMzURWsrP4piby7LpeOT+3Iq8CQNj4gXZdcH9w15Vuk2qS11at6IsQPVHpKD9HGg9//EFUccI/4w06k4XXLm/IxOGUwj6I2AeWmEOL3aDi+fe07TTosSdLUD6INtR0cyKsg0zC7Da24ixoShT8Oy3x2MpR7CY3PQ1pUVmvPkr79VeA+4qV9F1JM09WdboAMZgWQZ+XrbtuBlGsyhpUHSCQOya+kOJ+bYryS+U7A+6nmTW3C9FX4FgFqTF89UHOC7V0zZQ==]}")
+    }
+
     def knownHosts(String s) {
         def f = temp.newFile("known_hosts")
         f.write(s)

--- a/src/test/groovy/net/schmizz/sshj/transport/verification/FingerprintVerifierSpec.groovy
+++ b/src/test/groovy/net/schmizz/sshj/transport/verification/FingerprintVerifierSpec.groovy
@@ -49,6 +49,16 @@ class FingerprintVerifierSpec extends Specification {
 
     }
 
+    def "should produce meaningful toString()"() {
+        given:
+        def verifier = FingerprintVerifier.getInstance("SHA1:2Fo8c/96zv32xc8GZWbOGYOlRak")
+
+        when:
+        def toStringValue = verifier.toString()
+
+        then:
+        toStringValue == "FingerprintVerifier{digestAlgorithm='SHA-1'}"
+    }
 
     def getPublicKey() {
         def lines = new File("src/test/resources/keytypes/test_ed25519.pub").readLines()


### PR DESCRIPTION
In the `KeyExchanger` class there is the following error logging:

`
        log.error("Disconnecting because none of the configured Host key verifiers ({}) could verify '{}' host key with fingerprint {} for {}:{}",
                hostVerifiers,
                KeyType.fromKey(key),
                SecurityUtils.getFingerprint(key),
                transport.getRemoteHost(),
                transport.getRemotePort());
`

However the `hostVerifiers`'s elements do not properly override the `toString()` method.

It would be nice to see actual contents of this array for debug purposes. 