### PR TITLE
Handle server initiated global requests

### DIFF
--- a/src/main/java/net/schmizz/sshj/connection/ConnectionImpl.java
+++ b/src/main/java/net/schmizz/sshj/connection/ConnectionImpl.java
@@ -130,6 +130,9 @@ public class ConnectionImpl
             getChannel(buf).handle(msg, buf);
         } else if (msg.in(80, 90)) {
             switch (msg) {
+                case GLOBAL_REQUEST:
+                    gotGlobalRequest(buf);
+                    break;
                 case REQUEST_SUCCESS:
                     gotGlobalReqResponse(buf);
                     break;
@@ -257,6 +260,20 @@ public class ConnectionImpl
         keepAlive.interrupt();
         ErrorNotifiable.Util.alertAll(error, channels.values());
         channels.clear();
+    }
+
+    private void gotGlobalRequest(SSHPacket buf)
+    throws ConnectionException, TransportException {
+        try {
+            final String requestName = buf.readString();
+            boolean wantReply = buf.readBoolean();
+            log.debug("Received GLOBAL_REQUEST `{}`; want reply: {}", requestName, wantReply);
+            if (wantReply) {
+                trans.write(new SSHPacket(Message.REQUEST_FAILURE));
+            }
+        } catch (Buffer.BufferException be) {
+            throw new ConnectionException(be);
+        }
     }
 
     @Override

--- a/src/main/java/net/schmizz/sshj/connection/ConnectionImpl.java
+++ b/src/main/java/net/schmizz/sshj/connection/ConnectionImpl.java
@@ -263,7 +263,7 @@ public class ConnectionImpl
     }
 
     private void gotGlobalRequest(SSHPacket buf)
-    throws ConnectionException, TransportException {
+            throws ConnectionException, TransportException {
         try {
             final String requestName = buf.readString();
             boolean wantReply = buf.readBoolean();


### PR DESCRIPTION
RFC 4254 section 4 states that either side of the connection
may send global requests at any time and that the receiver
MUST respond appropriately.

This PR replaces the default logic of responding with 'UNIMPLEMENTED'
with the correct 'MSG_REQUEST_FAILURE' if 'wantReply' is set.