### PR TITLE
Use nano time instead of current time millis.

### DIFF
--- a/src/main/java/net/schmizz/sshj/common/StreamCopier.java
+++ b/src/main/java/net/schmizz/sshj/common/StreamCopier.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.concurrent.TimeUnit;
 
 public class StreamCopier {
 
@@ -125,7 +126,7 @@ public class StreamCopier {
         long count = 0;
         int read = 0;
 
-        final long startTime = System.currentTimeMillis();
+        final long startTime = System.nanoTime();
 
         if (length == -1) {
             while ((read = in.read(buf)) != -1) {
@@ -140,7 +141,7 @@ public class StreamCopier {
         if (!keepFlushing)
             out.flush();
 
-        final double timeSeconds = (System.currentTimeMillis() - startTime) / 1000.0;
+        final double timeSeconds = TimeUnit.NANOSECONDS.toMillis (System.nanoTime() - startTime) / 1000.0;
         final double sizeKiB = count / 1024.0;
         log.debug(String.format("%1$,.1f KiB transferred in %2$,.1f seconds (%3$,.2f KiB/s)", sizeKiB, timeSeconds, (sizeKiB / timeSeconds)));
 

--- a/src/test/java/net/schmizz/sshj/common/StreamCopierTest.java
+++ b/src/test/java/net/schmizz/sshj/common/StreamCopierTest.java
@@ -1,0 +1,35 @@
+package net.schmizz.sshj.common;
+
+
+import org.junit.Test;
+
+import java.io.*;
+import java.util.Random;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+
+public class StreamCopierTest {
+
+    @Test
+    public void copy() throws IOException {
+        Random random = new Random();
+        byte[] data = new byte[1024];
+        random.nextBytes(data);
+        InputStream inputStream = new ByteArrayInputStream(data);
+
+        OutputStream outputStream = new ByteArrayOutputStream();
+        LoggerFactory loggerFactory = mock(LoggerFactory.class);
+
+        org.slf4j.Logger logger= mock(org.slf4j.Logger.class);
+        when(loggerFactory.getLogger(StreamCopier.class)).thenReturn(logger);
+        StreamCopier streamCopier = new StreamCopier(inputStream,outputStream,loggerFactory);
+
+        long copied =streamCopier.copy();
+        assertThat(copied,is(1024l));
+
+        verify(logger).debug(contains("1.0 KiB transferred"));
+    }
+}

--- a/src/test/java/net/schmizz/sshj/common/StreamCopierTest.java
+++ b/src/test/java/net/schmizz/sshj/common/StreamCopierTest.java
@@ -1,5 +1,19 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.schmizz.sshj.common;
-
 
 import org.junit.Test;
 
@@ -23,12 +37,12 @@ public class StreamCopierTest {
         OutputStream outputStream = new ByteArrayOutputStream();
         LoggerFactory loggerFactory = mock(LoggerFactory.class);
 
-        org.slf4j.Logger logger= mock(org.slf4j.Logger.class);
+        org.slf4j.Logger logger = mock(org.slf4j.Logger.class);
         when(loggerFactory.getLogger(StreamCopier.class)).thenReturn(logger);
-        StreamCopier streamCopier = new StreamCopier(inputStream,outputStream,loggerFactory);
+        StreamCopier streamCopier = new StreamCopier(inputStream, outputStream, loggerFactory);
 
-        long copied =streamCopier.copy();
-        assertThat(copied,is(1024l));
+        long copied = streamCopier.copy();
+        assertThat(copied, is(1024L));
 
         verify(logger).debug(contains("1.0 KiB transferred"));
     }


### PR DESCRIPTION
Relative time should be measured by System.nanoTime instead of System.currentTimeMillis

currentTimeMillis might return incorrect results during time adjustments, for example day light savings adjustments.