### PR TITLE
Improve interoperability with Android Keystore

### DIFF
--- a/src/main/java/net/schmizz/sshj/common/KeyType.java
+++ b/src/main/java/net/schmizz/sshj/common/KeyType.java
@@ -66,7 +66,7 @@ public enum KeyType {
 
         @Override
         protected boolean isMyType(Key key) {
-            return (key instanceof RSAPublicKey || key instanceof RSAPrivateKey);
+            return "RSA".equals(key.getAlgorithm());
         }
     },
 
@@ -99,7 +99,7 @@ public enum KeyType {
 
         @Override
         protected boolean isMyType(Key key) {
-            return (key instanceof DSAPublicKey || key instanceof DSAPrivateKey);
+            return "DSA".equals(key.getAlgorithm());
         }
 
     },


### PR DESCRIPTION
Make the KeyTypes RSA and DSA detect keys of their type via their algorithm attribute rather than their instance type. This makes it possible to use RSA/DSA keys stored in the Android Keystore with SSHJ.