### PR TITLE
Add pwdf retry logic to OpenSSHKeyV1KeyFile

### DIFF
--- a/src/main/java/com/hierynomus/sshj/common/KeyDecryptionFailedException.java
+++ b/src/main/java/com/hierynomus/sshj/common/KeyDecryptionFailedException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.common;
+
+import org.bouncycastle.openssl.EncryptionException;
+
+import java.io.IOException;
+
+/**
+ * Thrown when a key file could not be decrypted correctly, e.g. if its checkInts differed in the case of an OpenSSH
+ * key file.
+ */
+public class KeyDecryptionFailedException extends IOException {
+
+    public static final String MESSAGE = "Decryption of the key failed. A supplied passphrase may be incorrect.";
+
+    public KeyDecryptionFailedException() {
+        super(MESSAGE);
+    }
+
+    public KeyDecryptionFailedException(EncryptionException cause) {
+        super(MESSAGE, cause);
+    }
+
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
@@ -28,6 +28,7 @@ import net.schmizz.sshj.userauth.keyprovider.KeyFormat;
 import org.bouncycastle.asn1.nist.NISTNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.jce.spec.ECNamedCurveSpec;
+import org.bouncycastle.openssl.EncryptionException;
 import org.mindrot.jbcrypt.BCrypt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,8 +112,16 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
             return readUnencrypted(privateKeyBuffer, publicKey);
         } else {
             logger.info("Keypair is encrypted with: " + cipherName + ", " + kdfName + ", " + Arrays.toString(kdfOptions));
-            PlainBuffer decrypted = decryptBuffer(privateKeyBuffer, cipherName, kdfName, kdfOptions);
-            return readUnencrypted(decrypted, publicKey);
+            while (true) {
+                PlainBuffer decryptionBuffer = new PlainBuffer(privateKeyBuffer);
+                PlainBuffer decrypted = decryptBuffer(decryptionBuffer, cipherName, kdfName, kdfOptions);
+                try {
+                    return readUnencrypted(decrypted, publicKey);
+                } catch (EncryptionException e) {
+                    if (pwdf == null || !pwdf.shouldRetry(resource))
+                        throw e;
+                }
+            }
 //            throw new IOException("Cannot read encrypted keypair with " + cipherName + " yet.");
         }
     }
@@ -184,7 +193,7 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
         int checkInt1 = keyBuffer.readUInt32AsInt(); // uint32 checkint1
         int checkInt2 = keyBuffer.readUInt32AsInt(); // uint32 checkint2
         if (checkInt1 != checkInt2) {
-            throw new IOException("The checkInts differed, the key was not correctly decoded.");
+            throw new EncryptionException("The checkInts differed, the key was not correctly decoded.");
         }
         // The private key section contains both the public key and the private key
         String keyType = keyBuffer.readString(); // string keytype

--- a/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS8KeyFile.java
+++ b/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS8KeyFile.java
@@ -15,6 +15,7 @@
  */
 package net.schmizz.sshj.userauth.keyprovider;
 
+import com.hierynomus.sshj.common.KeyDecryptionFailedException;
 import net.schmizz.sshj.common.IOUtils;
 import net.schmizz.sshj.common.SecurityUtils;
 import net.schmizz.sshj.userauth.password.PasswordUtils;
@@ -85,7 +86,7 @@ public class PKCS8KeyFile extends BaseFileKeyProvider {
                 if (pwdf != null && pwdf.shouldRetry(resource))
                     continue;
                 else
-                    throw e;
+                    throw new KeyDecryptionFailedException(e);
             } finally {
                 IOUtils.closeQuietly(r);
             }


### PR DESCRIPTION
While PKCS8KeyFile uses PasswordFinder's shouldRetry to determine
whether it should call reqPassword again if decryption of they key file
fails, OpenSSHKeyV1KeyFile simply gives up and throws an exception.

With this commit, retry logic similar to that of PKCS8KeyFile is added
to OpenSSHKeyV1KeyFile. The PasswordFinder's reqPassword is called
again if the validation of the "checkint" fails, which indicates an
incorrect passphrase.