### PR TITLE
Don't specify JcaPEM providers as null

### DIFF
--- a/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS8KeyFile.java
+++ b/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS8KeyFile.java
@@ -64,7 +64,9 @@ public class PKCS8KeyFile extends BaseFileKeyProvider {
                 final Object o = r.readObject();
 
                 final JcaPEMKeyConverter pemConverter = new JcaPEMKeyConverter();
-                pemConverter.setProvider(SecurityUtils.getSecurityProvider());
+                if (SecurityUtils.getSecurityProvider() != null) {
+                    pemConverter.setProvider(SecurityUtils.getSecurityProvider());
+                }    
 
                 if (o instanceof PEMEncryptedKeyPair) {
                     final PEMEncryptedKeyPair encryptedKeyPair = (PEMEncryptedKeyPair) o;

--- a/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS8KeyFile.java
+++ b/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS8KeyFile.java
@@ -71,7 +71,9 @@ public class PKCS8KeyFile extends BaseFileKeyProvider {
                 if (o instanceof PEMEncryptedKeyPair) {
                     final PEMEncryptedKeyPair encryptedKeyPair = (PEMEncryptedKeyPair) o;
                     JcePEMDecryptorProviderBuilder decryptorBuilder = new JcePEMDecryptorProviderBuilder();
-                    decryptorBuilder.setProvider(SecurityUtils.getSecurityProvider());
+                    if (SecurityUtils.getSecurityProvider() != null) {
+                        decryptorBuilder.setProvider(SecurityUtils.getSecurityProvider());
+                    }
                     try {
                         passphrase = pwdf == null ? null : pwdf.reqPassword(resource);
                         kp = pemConverter.getKeyPair(encryptedKeyPair.decryptKeyPair(decryptorBuilder.build(passphrase)));


### PR DESCRIPTION
If no provider is set in the `SecurityUtils`, no named provider should be set for the `JcaPEMKeyConverter` as this would cause a `missing provider` exception. This currently breaks `PKCS8KeyFile` if `SecurityUtils.setSecurityProvider(null)` and `SecurityUtils.setRegisterBouncyCastle(false)` is used.