### PR TITLE
Allow all configured KeyAlgorithms for pubkey auth

### DIFF
--- a/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
+++ b/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
@@ -232,12 +232,6 @@ final class KeyExchanger
         kex = Factory.Named.Util.create(transport.getConfig().getKeyExchangeFactories(),
                                         negotiatedAlgs.getKeyExchangeAlgorithm());
 
-        List<KeyAlgorithm> keyAlgorithms = new ArrayList<KeyAlgorithm>();
-        for (String signatureAlgorithm : negotiatedAlgs.getSignatureAlgorithms()) {
-            keyAlgorithms.add(Factory.Named.Util.create(transport.getConfig().getKeyAlgorithms(), signatureAlgorithm));
-        }
-        transport.setKeyAlgorithms(keyAlgorithms);
-
         try {
             kex.init(transport,
                      transport.getServerID(), transport.getClientID(),

--- a/src/main/java/net/schmizz/sshj/transport/Transport.java
+++ b/src/main/java/net/schmizz/sshj/transport/Transport.java
@@ -237,6 +237,4 @@ public interface Transport
      * @param e The exception that occurred.
      */
     void die(Exception e);
-
-    KeyAlgorithm getKeyAlgorithm(KeyType keyType) throws TransportException;
 }

--- a/src/main/java/net/schmizz/sshj/transport/TransportImpl.java
+++ b/src/main/java/net/schmizz/sshj/transport/TransportImpl.java
@@ -653,19 +653,4 @@ public final class TransportImpl
     ConnInfo getConnInfo() {
         return connInfo;
     }
-
-    @Override
-    public KeyAlgorithm getKeyAlgorithm(KeyType keyType) throws TransportException {
-        for (KeyAlgorithm ka : keyAlgorithms) {
-            if (ka.getKeyFormat().equals(keyType)) {
-                return ka;
-            }
-        }
-
-        throw new TransportException("Cannot find an available KeyAlgorithm for type " + keyType);
-    }
-
-    public void setKeyAlgorithms(List<KeyAlgorithm> keyAlgorithms) {
-        this.keyAlgorithms = keyAlgorithms;
-    }
 }

--- a/src/main/java/net/schmizz/sshj/transport/kex/AbstractDHGex.java
+++ b/src/main/java/net/schmizz/sshj/transport/kex/AbstractDHGex.java
@@ -85,8 +85,14 @@ public abstract class AbstractDHGex extends AbstractDH {
                 .putMPInt(k);
         digest.update(buf.array(), buf.rpos(), buf.available());
         H = digest.digest();
-        KeyAlgorithm keyAlgorithm = trans.getKeyAlgorithm(KeyType.fromKey(hostKey));
-        Signature signature = keyAlgorithm.newSignature();
+        final KeyType keyType = KeyType.fromKey(hostKey);
+        final KeyAlgorithm keyAlgorithm = Factory.Named.Util.create(trans.getConfig().getKeyAlgorithms(),
+                keyType.toString());
+        if (keyAlgorithm == null)
+            throw new TransportException(DisconnectReason.KEY_EXCHANGE_FAILED,
+                    "No KeyAlgorithm configured for key " + keyType);
+
+        final Signature signature = keyAlgorithm.newSignature();
         signature.initVerify(hostKey);
         signature.update(H, 0, H.length);
         if (!signature.verify(sig))


### PR DESCRIPTION
Makes all configured KeyAlgorithms usable for pubkey auth instead of
just those that also happen to be available as host key types on the
server.

Fixes #600 for me.