### PR TITLE
Always use JCERandom as the default RNG

### DIFF
--- a/src/main/java/net/schmizz/sshj/DefaultConfig.java
+++ b/src/main/java/net/schmizz/sshj/DefaultConfig.java
@@ -146,8 +146,7 @@ public class DefaultConfig
     }
 
     protected void initRandomFactory(boolean bouncyCastleRegistered) {
-        setRandomFactory(new SingletonRandomFactory(bouncyCastleRegistered
-                ? new BouncyCastleRandom.Factory() : new JCERandom.Factory()));
+        setRandomFactory(new SingletonRandomFactory(new JCERandom.Factory()));
     }
 
     protected void initFileKeyProviderFactories(boolean bouncyCastleRegistered) {


### PR DESCRIPTION
The current implementation relies on `VMPCRandomGenerator` for random number generation if BouncyCastle is registered, otherwise it falls back to `SecureRandom`. Nowadays, `SecureRandom` should always be the best available option, whereas `VMPCRandomGenerator` [has known weaknesses](https://books.google.de/books?id=niO6BQAAQBAJ&pg=PA140&lpg=PA140&dq=vmpc+prng&source=bl&ots=QAdZJOT607&sig=ACfU3U0Edqlpm08iRZJLxeWGQNwNQz7WsQ&hl=en&sa=X&ved=2ahUKEwjd2Zyr9pfqAhXWMMAKHT70AioQ6AEwDnoECAoQAQ#v=onepage&q=vmpc%20prng&f=false).