### PR TITLE
Fix localport for openssh >= 8.0

### DIFF
--- a/src/main/java/net/schmizz/sshj/connection/channel/direct/DirectConnection.java
+++ b/src/main/java/net/schmizz/sshj/connection/channel/direct/DirectConnection.java
@@ -20,7 +20,7 @@ import net.schmizz.sshj.connection.Connection;
 /** A channel for creating a direct TCP/IP connection from the server to a remote address. */
 public class DirectConnection extends DirectTCPIPChannel {
     public static final String LOCALHOST = "localhost";
-    public static final int LOCALPORT = 65536;
+    public static final int LOCALPORT = 65535;
 
     public DirectConnection(Connection conn, String remoteHost, int remotePort) {
         super(conn, new Parameters(LOCALHOST, LOCALPORT, remoteHost, remotePort));


### PR DESCRIPTION
This pullrequest fixed #555. Since openssh 8.0 the serve will check that the originator port has a valid port. 65536 is not a valid port as per definition. So we just fallback and use the last possible port which is 65535.

[Link to rfc](https://tools.ietf.org/html/rfc7605#:~:text=Current%20Port%20Number%20Use,-RFC%206335%20indicates&text=The%20port%20numbers%20from%201024,port%20numbers%20are%20not%20assigned.)