### PR TITLE
Avoid key leakage.

### DIFF
--- a/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS5KeyFile.java
+++ b/src/main/java/net/schmizz/sshj/userauth/keyprovider/PKCS5KeyFile.java
@@ -99,7 +99,7 @@ public class PKCS5KeyFile extends BaseFileKeyProvider {
                         } else if ("DSS".equals(s)) {
                             type = KeyType.DSA;
                         } else {
-                            throw new FormatException("Unrecognized PKCS5 key type: " + s);
+                            throw new FormatException("Unrecognized PKCS5 key type");
                         }
                     } else {
                         throw new FormatException("Bad header; possibly PKCS8 format?");
@@ -109,12 +109,12 @@ public class PKCS5KeyFile extends BaseFileKeyProvider {
                 } else if (type != null) {
                     if (line.startsWith("Proc-Type: ")) {
                         if (!"4,ENCRYPTED".equals(line.substring(11))) {
-                            throw new FormatException("Unrecognized Proc-Type: " + line.substring(11));
+                            throw new FormatException("Unrecognized Proc-Type");
                         }
                     } else if (line.startsWith("DEK-Info: ")) {
                         int ptr = line.indexOf(",");
                         if (ptr == -1) {
-                            throw new FormatException("Unrecognized DEK-Info: " + line.substring(10));
+                            throw new FormatException("Unrecognized DEK-Info");
                         } else {
                             String algorithm = line.substring(10, ptr);
                             if ("DES-EDE3-CBC".equals(algorithm)) {


### PR DESCRIPTION
In some cases, current code will leak parts or even the whole ssh key if it's slightly malformed.
One example of that malformation will be a key, where all newlines are replaced by other character, thus turning a multiline key to a single big string.
Then that whole line will be leaked to exception message. Thus I suggest to completely remove any parts of key from getting into the exception.