### PR TITLE
fix keep-alive thread never be closed

### DIFF
--- a/src/main/java/net/schmizz/sshj/SSHClient.java
+++ b/src/main/java/net/schmizz/sshj/SSHClient.java
@@ -142,7 +142,9 @@ public class SSHClient
 	log = loggerFactory.getLogger(getClass());
         this.trans = new TransportImpl(config, this);
         this.auth = new UserAuthImpl(trans);
-        this.conn = new ConnectionImpl(trans, config.getKeepAliveProvider());
+	ConnectionImpl connectionImpl = new ConnectionImpl(trans, config.getKeepAliveProvider());
+        this.conn = connectionImpl;
+	this.trans.setService(connectionImpl);
     }
 
     /**


### PR DESCRIPTION
TransportImpl have a default serivce as nullService, when you set keepAlive to retain connection, a keep-alive thread will be create and periodic send msg to remote. but even after sshClient.close() has been called. this keepAlive will still exist. 
So, the solution is to set a ConnectionImpl object to TransportImpl.