### PR TITLE
Improve Android compatibility

### DIFF
--- a/src/main/java/net/schmizz/sshj/common/SecurityUtils.java
+++ b/src/main/java/net/schmizz/sshj/common/SecurityUtils.java
@@ -249,7 +249,14 @@ public class SecurityUtils {
      */
     public static synchronized boolean isBouncyCastleRegistered() {
         register();
-        return BOUNCY_CASTLE.equals(securityProvider) || SPONGY_CASTLE.equals(securityProvider);
+        Provider[] providers = Security.getProviders();
+        for (Provider provider : providers) {
+            String name = provider.getName();
+            if (BOUNCY_CASTLE.equals(name) || SPONGY_CASTLE.equals(name)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static synchronized void setRegisterBouncyCastle(boolean registerBouncyCastle) {

--- a/src/main/java/net/schmizz/sshj/transport/kex/ECDHNistP.java
+++ b/src/main/java/net/schmizz/sshj/transport/kex/ECDHNistP.java
@@ -19,9 +19,9 @@ import net.schmizz.sshj.transport.digest.Digest;
 import net.schmizz.sshj.transport.digest.SHA256;
 import net.schmizz.sshj.transport.digest.SHA384;
 import net.schmizz.sshj.transport.digest.SHA512;
-import org.bouncycastle.jce.spec.ECNamedCurveGenParameterSpec;
 
 import java.security.GeneralSecurityException;
+import java.security.spec.ECGenParameterSpec;
 
 public class ECDHNistP extends AbstractDHG {
 
@@ -33,7 +33,7 @@ public class ECDHNistP extends AbstractDHG {
 
         @Override
         public KeyExchange create() {
-            return new ECDHNistP("P-521", new SHA512());
+            return new ECDHNistP("secp521r1", new SHA512());
         }
 
         @Override
@@ -48,7 +48,7 @@ public class ECDHNistP extends AbstractDHG {
 
         @Override
         public KeyExchange create() {
-            return new ECDHNistP("P-384", new SHA384());
+            return new ECDHNistP("secp384r1", new SHA384());
         }
 
         @Override
@@ -63,7 +63,7 @@ public class ECDHNistP extends AbstractDHG {
 
         @Override
         public KeyExchange create() {
-            return new ECDHNistP("P-256", new SHA256());
+            return new ECDHNistP("secp256r1", new SHA256());
         }
 
         @Override
@@ -79,7 +79,7 @@ public class ECDHNistP extends AbstractDHG {
 
     @Override
     protected void initDH(DHBase dh) throws GeneralSecurityException {
-        dh.init(new ECNamedCurveGenParameterSpec(curve), trans.getConfig().getRandomFactory());
+        dh.init(new ECGenParameterSpec(curve), trans.getConfig().getRandomFactory());
     }
 
 }


### PR DESCRIPTION
* Instead of only counting BouncyCastle as being registered if it is set as the explicit security provider used by SSHJ, count it as
registered if it is available as a provider. This improves Android compatibility, which requires not specifying an explicit provider. This is meant to address https://github.com/hierynomus/sshj/pull/586#issuecomment-704006627 

@oakkitten Could you verify that this fixes the issue with ECDSA host keys?

* The ECNamedCurveGenParameterSpec is a BC-specific workaround for missing curve tables in Java 1.4 and earlier. For the sake of Android compatibility, where Conscrypt can't deal with this custom spec class, replace it with the standard ECGenParameterSpec and update the curve names to the standard identifiers.