### PR TITLE
reduced log level for lenient handling of missing CR

### DIFF
--- a/src/main/java/com/hierynomus/sshj/transport/IdentificationStringParser.java
+++ b/src/main/java/com/hierynomus/sshj/transport/IdentificationStringParser.java
@@ -79,11 +79,9 @@ public class IdentificationStringParser {
         }
         if (bytes[bytes.length - 2] != '\r') {
             String ident = new String(bytes, 0, bytes.length - 1);
-            log.warn("Server identification has bad line ending, was expecting a '\\r\\n' however got: '{}' (hex: {})", (char) (bytes[bytes.length - 2] & 0xFF), Integer.toHexString(bytes[bytes.length - 2] & 0xFF));
-            log.warn("Will treat the identification of this server '{}' leniently", ident);
+            log.info("Server identification has bad line ending, was expecting a '\\r\\n' however got: '{}' (hex: {})", (char) (bytes[bytes.length - 2] & 0xFF), Integer.toHexString(bytes[bytes.length - 2] & 0xFF));
+            log.info("Will treat the identification of this server '{}' leniently", ident);
             return ident;
-            // log.error("Data received up til here was: {}", new String(bytes));
-            // throw new TransportException("Incorrect identification: bad line ending: " + ByteArrayUtils.toHex(bytes, 0, bytes.length));
         }
 
         // Strip off the \r\n


### PR DESCRIPTION
Currently, sshj logs a warning when a a server identifies itself with a string that is not terminated as expected with CR LF but only LF.

As a user of ssh, I may have no control over the server I am connecting to and can do nothing to remediate the underlying issue. At the same time, sshj handles this situation very gracefully. Therefore, I'd consider the log level _warning_ as too high.

To ensure helpful logging of the library, I suggest to reduce the log level from _warn_ to _info_.