### PR TITLE
Bump bouncycastle version

### DIFF
--- a/build-publishing.gradle
+++ b/build-publishing.gradle
@@ -17,7 +17,7 @@ configurations {
   pom
 }
 
-def bouncycastleVersion = "1.66"
+def bouncycastleVersion = "1.67"
 
 dependencies {
   compile "org.slf4j:slf4j-api:1.7.7"

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 
 configurations.compile.transitive = false
 
-def bouncycastleVersion = "1.66"
+def bouncycastleVersion = "1.67"
 def sshdVersion = "2.1.0"
 
 dependencies {


### PR DESCRIPTION
[Bouncy Castle 1.65 and 1.66 are vulnerable to CVE-2020-28052](https://github.com/bcgit/bc-java/wiki/CVE-2020-28052).

I think this isn't relevant for SSHJ directly but for people getting Bouncy Castle transitively via SSHJ.

I couldn't test this PR, the `:jar` task fails on my machine when copying `MANIFEST.MF`.