### PR TITLE
Replace com.hierynomus.asn1 with org.bouncycastle.asn1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,6 @@ dependencies {
   implementation "org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion"
   implementation "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
   implementation "com.jcraft:jzlib:1.1.3"
-  implementation "com.hierynomus:asn-one:0.6.0"
-
   implementation "net.i2p.crypto:eddsa:0.3.0"
 
   testImplementation "junit:junit:4.12"

--- a/src/main/java/net/schmizz/sshj/signature/AbstractSignatureDSA.java
+++ b/src/main/java/net/schmizz/sshj/signature/AbstractSignatureDSA.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.schmizz.sshj.signature;
+
+import org.bouncycastle.asn1.ASN1Encoding;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1OutputStream;
+import org.bouncycastle.asn1.DERSequence;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+
+public abstract class AbstractSignatureDSA extends AbstractSignature {
+    protected AbstractSignatureDSA(String algorithm, String signatureName) {
+        super(algorithm, signatureName);
+    }
+
+    /**
+     * Get ASN.1 Signature encoded using DER Sequence of integers
+     *
+     * @param r DSA Signature R
+     * @param s DSA Signature S
+     * @return ASN.1 Encoded Signature
+     * @throws IOException Thrown when failing to write signature integers
+     */
+    protected byte[] getAsnEncodedSignature(final BigInteger r, final BigInteger s) throws IOException {
+        final ASN1Integer[] integers = new ASN1Integer[] { new ASN1Integer(r), new ASN1Integer(s) };
+        final DERSequence sequence = new DERSequence(integers);
+
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        final ASN1OutputStream asn1OutputStream = ASN1OutputStream.create(byteArrayOutputStream, ASN1Encoding.DER);
+        asn1OutputStream.writeObject(sequence);
+        asn1OutputStream.flush();
+        asn1OutputStream.close();
+        return byteArrayOutputStream.toByteArray();
+    }
+}


### PR DESCRIPTION
This pull request replaces uses of `com.hierynomus.asn1` classes with equivalent `org.bouncycastle.asn1` classes. With the direct dependency on Bouncy Castle for parsing private keys and other operations, this refactor removes the need for a dependency on `com.hierynomus:asn-one`. This addresses issue #678 and reduces the overall number of dependencies. Current unit tests for `SignatureDSA` and `SignatureECDSA` continue running as designed without modification.