### PR TITLE
Prefer known algorithm for known host

### DIFF
--- a/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
+++ b/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
@@ -170,20 +170,20 @@ final class KeyExchanger
     private void sendKexInit()
             throws TransportException {
         log.debug("Sending SSH_MSG_KEXINIT");
-        String knowHostAlg = findKnowHostAlg(transport.getRemoteHost(), transport.getRemotePort());
-        clientProposal = new Proposal(transport.getConfig(), knowHostAlg);
+        List<String> knownHostAlgs = findKnownHostAlgs(transport.getRemoteHost(), transport.getRemotePort());
+        clientProposal = new Proposal(transport.getConfig(), knownHostAlgs);
         transport.write(clientProposal.getPacket());
         kexInitSent.set();
     }
 
-    private String findKnowHostAlg(String hostname, int port) {
+    private List<String> findKnownHostAlgs(String hostname, int port) {
         for (HostKeyVerifier hkv : hostVerifiers) {
-            String keyType = hkv.findExistingAlgorithm(hostname, port);
-            if (keyType != null) {
-                return keyType;
+            List<String> keyTypes = hkv.findExistingAlgorithms(hostname, port);
+            if (keyTypes != null && !keyTypes.isEmpty()) {
+                return keyTypes;
             }
         }
-        return null;
+        return Collections.emptyList();
     }
 
     private void sendNewKeys()

--- a/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
+++ b/src/main/java/net/schmizz/sshj/transport/KeyExchanger.java
@@ -170,9 +170,20 @@ final class KeyExchanger
     private void sendKexInit()
             throws TransportException {
         log.debug("Sending SSH_MSG_KEXINIT");
-        clientProposal = new Proposal(transport.getConfig());
+        String knowHostAlg = findKnowHostAlg(transport.getRemoteHost(), transport.getRemotePort());
+        clientProposal = new Proposal(transport.getConfig(), knowHostAlg);
         transport.write(clientProposal.getPacket());
         kexInitSent.set();
+    }
+
+    private String findKnowHostAlg(String hostname, int port) {
+        for (HostKeyVerifier hkv : hostVerifiers) {
+            String keyType = hkv.findExistingAlgorithm(hostname, port);
+            if (keyType != null) {
+                return keyType;
+            }
+        }
+        return null;
     }
 
     private void sendNewKeys()

--- a/src/main/java/net/schmizz/sshj/transport/Proposal.java
+++ b/src/main/java/net/schmizz/sshj/transport/Proposal.java
@@ -38,21 +38,9 @@ class Proposal {
     private final List<String> s2cComp;
     private final SSHPacket packet;
 
-    public Proposal(Config config, String knowHostAlg) {
+    public Proposal(Config config, List<String> knownHostAlgs) {
         kex = Factory.Named.Util.getNames(config.getKeyExchangeFactories());
-        if (knowHostAlg != null) {
-            List<String> pSig = Factory.Named.Util.getNames(config.getKeyAlgorithms());
-            if (pSig.contains(knowHostAlg)) {
-                ArrayList<String> sigT = new ArrayList<>();
-                sigT.add(knowHostAlg);
-                sigT.addAll(pSig);
-                sig = sigT;
-            } else {
-                sig = pSig;
-            }
-        } else {
-            sig = Factory.Named.Util.getNames(config.getKeyAlgorithms());
-        }
+        sig = filterKnownHostKeyAlgorithms(Factory.Named.Util.getNames(config.getKeyAlgorithms()), knownHostAlgs);
         c2sCipher = s2cCipher = Factory.Named.Util.getNames(config.getCipherFactories());
         c2sMAC = s2cMAC = Factory.Named.Util.getNames(config.getMACFactories());
         c2sComp = s2cComp = Factory.Named.Util.getNames(config.getCompressionFactories());
@@ -139,32 +127,43 @@ class Proposal {
     public NegotiatedAlgorithms negotiate(Proposal other)
             throws TransportException {
         return new NegotiatedAlgorithms(
-                firstMatch("KeyExchangeAlgorithms",
-                           this.getKeyExchangeAlgorithms(),
-                           other.getKeyExchangeAlgorithms()),
-                firstMatch("HostKeyAlgorithms",
-                           this.getHostKeyAlgorithms(),
-                           other.getHostKeyAlgorithms()),
-                firstMatch("Client2ServerCipherAlgorithms",
-                           this.getClient2ServerCipherAlgorithms(),
-                           other.getClient2ServerCipherAlgorithms()),
-                firstMatch("Server2ClientCipherAlgorithms",
-                           this.getServer2ClientCipherAlgorithms(),
-                           other.getServer2ClientCipherAlgorithms()),
-                firstMatch("Client2ServerMACAlgorithms",
-                           this.getClient2ServerMACAlgorithms(),
-                           other.getClient2ServerMACAlgorithms()),
-                firstMatch("Server2ClientMACAlgorithms",
-                           this.getServer2ClientMACAlgorithms(),
-                           other.getServer2ClientMACAlgorithms()),
-                firstMatch("Client2ServerCompressionAlgorithms",
-                           this.getClient2ServerCompressionAlgorithms(),
-                           other.getClient2ServerCompressionAlgorithms()),
-                firstMatch("Server2ClientCompressionAlgorithms",
-                           this.getServer2ClientCompressionAlgorithms(),
-                           other.getServer2ClientCompressionAlgorithms()),
-                other.getHostKeyAlgorithms().containsAll(KeyAlgorithms.SSH_RSA_SHA2_ALGORITHMS)
-        );
+                firstMatch("KeyExchangeAlgorithms", this.getKeyExchangeAlgorithms(), other.getKeyExchangeAlgorithms()),
+                firstMatch("HostKeyAlgorithms", this.getHostKeyAlgorithms(), other.getHostKeyAlgorithms()),
+                firstMatch("Client2ServerCipherAlgorithms", this.getClient2ServerCipherAlgorithms(),
+                        other.getClient2ServerCipherAlgorithms()),
+                firstMatch("Server2ClientCipherAlgorithms", this.getServer2ClientCipherAlgorithms(),
+                        other.getServer2ClientCipherAlgorithms()),
+                firstMatch("Client2ServerMACAlgorithms", this.getClient2ServerMACAlgorithms(),
+                        other.getClient2ServerMACAlgorithms()),
+                firstMatch("Server2ClientMACAlgorithms", this.getServer2ClientMACAlgorithms(),
+                        other.getServer2ClientMACAlgorithms()),
+                firstMatch("Client2ServerCompressionAlgorithms", this.getClient2ServerCompressionAlgorithms(),
+                        other.getClient2ServerCompressionAlgorithms()),
+                firstMatch("Server2ClientCompressionAlgorithms", this.getServer2ClientCompressionAlgorithms(),
+                        other.getServer2ClientCompressionAlgorithms()),
+                other.getHostKeyAlgorithms().containsAll(KeyAlgorithms.SSH_RSA_SHA2_ALGORITHMS));
+    }
+
+    private List<String> filterKnownHostKeyAlgorithms(List<String> configuredKeyAlgorithms, List<String> knownHostKeyAlgorithms) {
+        if (knownHostKeyAlgorithms != null && !knownHostKeyAlgorithms.isEmpty()) {
+            List<String> preferredAlgorithms = new ArrayList<String>();
+            List<String> otherAlgorithms = new ArrayList<String>();
+
+            for (String configuredKeyAlgorithm : configuredKeyAlgorithms) {
+                if (knownHostKeyAlgorithms.contains(configuredKeyAlgorithm)) {
+                    preferredAlgorithms.add(configuredKeyAlgorithm);
+                } else {
+                    otherAlgorithms.add(configuredKeyAlgorithm);
+                }
+            }
+
+            preferredAlgorithms.addAll(otherAlgorithms);
+
+            return preferredAlgorithms;
+        } else {
+            return configuredKeyAlgorithms;
+        }
+
     }
 
     private static String firstMatch(String ofWhat, List<String> a, List<String> b)

--- a/src/main/java/net/schmizz/sshj/transport/Proposal.java
+++ b/src/main/java/net/schmizz/sshj/transport/Proposal.java
@@ -38,9 +38,21 @@ class Proposal {
     private final List<String> s2cComp;
     private final SSHPacket packet;
 
-    public Proposal(Config config) {
+    public Proposal(Config config, String knowHostAlg) {
         kex = Factory.Named.Util.getNames(config.getKeyExchangeFactories());
-        sig = Factory.Named.Util.getNames(config.getKeyAlgorithms());
+        if (knowHostAlg != null) {
+            List<String> pSig = Factory.Named.Util.getNames(config.getKeyAlgorithms());
+            if (pSig.contains(knowHostAlg)) {
+                ArrayList<String> sigT = new ArrayList<>();
+                sigT.add(knowHostAlg);
+                sigT.addAll(pSig);
+                sig = sigT;
+            } else {
+                sig = pSig;
+            }
+        } else {
+            sig = Factory.Named.Util.getNames(config.getKeyAlgorithms());
+        }
         c2sCipher = s2cCipher = Factory.Named.Util.getNames(config.getCipherFactories());
         c2sMAC = s2cMAC = Factory.Named.Util.getNames(config.getMACFactories());
         c2sComp = s2cComp = Factory.Named.Util.getNames(config.getCompressionFactories());

--- a/src/main/java/net/schmizz/sshj/transport/verification/FingerprintVerifier.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/FingerprintVerifier.java
@@ -20,6 +20,8 @@ import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.PublicKey;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import net.schmizz.sshj.common.Base64;
@@ -76,8 +78,8 @@ public class FingerprintVerifier implements HostKeyVerifier {
                 }
 
                 @Override
-                public String findExistingAlgorithm(String hostname, int port) {
-                    return null;
+                public List<String> findExistingAlgorithms(String hostname, int port) {
+                    return Collections.emptyList();
                 }
             });
         } catch (SSHRuntimeException e) {
@@ -126,8 +128,8 @@ public class FingerprintVerifier implements HostKeyVerifier {
     }
 
     @Override
-    public String findExistingAlgorithm(String hostname, int port) {
-        return null;
+    public List<String> findExistingAlgorithms(String hostname, int port) {
+        return Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/net/schmizz/sshj/transport/verification/FingerprintVerifier.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/FingerprintVerifier.java
@@ -74,6 +74,11 @@ public class FingerprintVerifier implements HostKeyVerifier {
                 public boolean verify(String h, int p, PublicKey k) {
                     return SecurityUtils.getFingerprint(k).equals(md5);
                 }
+
+                @Override
+                public String findExistingAlgorithm(String hostname, int port) {
+                    return null;
+                }
             });
         } catch (SSHRuntimeException e) {
             throw e;
@@ -118,6 +123,11 @@ public class FingerprintVerifier implements HostKeyVerifier {
 
         byte[] digestData = digest.digest();
         return Arrays.equals(fingerprintData, digestData);
+    }
+
+    @Override
+    public String findExistingAlgorithm(String hostname, int port) {
+        return null;
     }
 
     @Override

--- a/src/main/java/net/schmizz/sshj/transport/verification/HostKeyVerifier.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/HostKeyVerifier.java
@@ -16,6 +16,7 @@
 package net.schmizz.sshj.transport.verification;
 
 import java.security.PublicKey;
+import java.util.List;
 
 /** Host key verification interface. */
 public interface HostKeyVerifier {
@@ -40,7 +41,7 @@ public interface HostKeyVerifier {
      * This will allow a match when we later verify with the negotiated key {@code HostKeyVerifier.verify}
      * @param hostname remote hostname
      * @param port     remote port
-     * @return existing key type or null if not key matches hostname
+     * @return existing key types or empty list if no keys known for hostname
      */
-    String findExistingAlgorithm(String hostname, int port);
+    List<String> findExistingAlgorithms(String hostname, int port);
 }

--- a/src/main/java/net/schmizz/sshj/transport/verification/HostKeyVerifier.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/HostKeyVerifier.java
@@ -35,4 +35,12 @@ public interface HostKeyVerifier {
      */
     boolean verify(String hostname, int port, PublicKey key);
 
+    /**
+     * It is necessary to connect with the type of algorithm that matches an existing know_host entry.
+     * This will allow a match when we later verify with the negotiated key {@code HostKeyVerifier.verify}
+     * @param hostname remote hostname
+     * @param port     remote port
+     * @return existing key type or null if not key matches hostname
+     */
+    String findExistingAlgorithm(String hostname, int port);
 }

--- a/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
@@ -90,6 +90,10 @@ public class OpenSSHKnownHosts
         }
     }
 
+    private String adjustHostname(final String hostname, final int port) {
+        String lowerHN = hostname.toLowerCase();
+        return (port != 22) ? "[" + lowerHN + "]:" + port : lowerHN;
+    }
 
     public File getFile() {
         return khFile;
@@ -103,7 +107,7 @@ public class OpenSSHKnownHosts
             return false;
         }
 
-        final String adjustedHostname = (port != 22) ? "[" + hostname + "]:" + port : hostname;
+        final String adjustedHostname = adjustHostname(hostname, port);
 
         boolean foundApplicableHostEntry = false;
         for (KnownHostEntry e : entries) {
@@ -125,6 +129,19 @@ public class OpenSSHKnownHosts
         }
 
         return hostKeyUnverifiableAction(adjustedHostname, key);
+    }
+
+    @Override
+    public String findExistingAlgorithm(String hostname, int port) {
+        final String adjustedHostname = adjustHostname(hostname, port);
+        for (KnownHostEntry e : entries) {
+            try {
+                if (e.appliesTo(adjustedHostname)) {
+                    return e.getType().toString();
+                }
+            } catch (IOException ioe) {}
+        }
+        return null;
     }
 
     protected boolean hostKeyUnverifiableAction(String hostname, PublicKey key) {

--- a/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/OpenSSHKnownHosts.java
@@ -132,16 +132,19 @@ public class OpenSSHKnownHosts
     }
 
     @Override
-    public String findExistingAlgorithm(String hostname, int port) {
+    public List<String> findExistingAlgorithms(String hostname, int port) {
         final String adjustedHostname = adjustHostname(hostname, port);
+        List<String> knownHostAlgorithms = new ArrayList<String>();
         for (KnownHostEntry e : entries) {
             try {
                 if (e.appliesTo(adjustedHostname)) {
-                    return e.getType().toString();
+                    knownHostAlgorithms.add(e.getType().toString());
                 }
-            } catch (IOException ioe) {}
+            } catch (IOException ioe) {
+            }
         }
-        return null;
+
+        return knownHostAlgorithms;
     }
 
     protected boolean hostKeyUnverifiableAction(String hostname, PublicKey key) {

--- a/src/main/java/net/schmizz/sshj/transport/verification/PromiscuousVerifier.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/PromiscuousVerifier.java
@@ -16,6 +16,8 @@
 package net.schmizz.sshj.transport.verification;
 
 import java.security.PublicKey;
+import java.util.Collections;
+import java.util.List;
 
 public final class PromiscuousVerifier
         implements HostKeyVerifier {
@@ -26,8 +28,8 @@ public final class PromiscuousVerifier
     }
 
     @Override
-    public String findExistingAlgorithm(String hostname, int port) {
-        return null;
+    public List<String> findExistingAlgorithms(String hostname, int port) {
+        return Collections.emptyList();
     }
 
 }

--- a/src/main/java/net/schmizz/sshj/transport/verification/PromiscuousVerifier.java
+++ b/src/main/java/net/schmizz/sshj/transport/verification/PromiscuousVerifier.java
@@ -25,4 +25,9 @@ public final class PromiscuousVerifier
         return true;
     }
 
+    @Override
+    public String findExistingAlgorithm(String hostname, int port) {
+        return null;
+    }
+
 }


### PR DESCRIPTION
(#642, #635... 10? issues)

Try to find the Algorithm that was used when a known_host
entry was created and make that the first choice for the
current connection attempt.

If the current connection algorithm matches the
algorithm used when the known_host entry was created
we can get a fair verification.