### PR TITLE
Upgrade SLF4J to 1.7.32 and Logback to 1.2.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def bouncycastleVersion = "1.69"
 def sshdVersion = "2.1.0"
 
 dependencies {
-  implementation "org.slf4j:slf4j-api:1.7.30"
+  implementation "org.slf4j:slf4j-api:1.7.32"
   implementation "org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion"
   implementation "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
   implementation "com.jcraft:jzlib:1.1.3"
@@ -59,7 +59,7 @@ dependencies {
   testImplementation "org.apache.sshd:sshd-core:$sshdVersion"
   testImplementation "org.apache.sshd:sshd-sftp:$sshdVersion"
   testImplementation "org.apache.sshd:sshd-scp:$sshdVersion"
-  testRuntimeOnly "ch.qos.logback:logback-classic:1.2.3"
+  testRuntimeOnly "ch.qos.logback:logback-classic:1.2.6"
   testImplementation 'org.glassfish.grizzly:grizzly-http-server:2.4.4'
   testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
 


### PR DESCRIPTION
This pull request upgrades [SLF4J](http://www.slf4j.org/news.html) from 1.7.30 to 1.7.32, and upgrades [Logback](http://logback.qos.ch/news.html) from 1.2.3 to 1.2.6.

These upgrades include several minor bug fixes in both libraries.