### PR TITLE
Update OpenSSH Key V1 parsing using CRT information for RSA Private Keys

### DIFF
--- a/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
@@ -293,7 +293,7 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
         final BigInteger modulus = buffer.readMPInt();
         final BigInteger publicExponent = buffer.readMPInt();
         final BigInteger privateExponent = buffer.readMPInt();
-        final BigInteger crtCoefficient = buffer.readMPInt();
+        final BigInteger crtCoefficient = buffer.readMPInt(); // iqmp (q^-1 mod p)
         final BigInteger primeP = buffer.readMPInt();
         final BigInteger primeQ = buffer.readMPInt();
 

--- a/src/test/java/net/schmizz/sshj/keyprovider/OpenSSHKeyFileTest.java
+++ b/src/test/java/net/schmizz/sshj/keyprovider/OpenSSHKeyFileTest.java
@@ -26,7 +26,6 @@ import net.schmizz.sshj.userauth.password.PasswordFinder;
 import net.schmizz.sshj.userauth.password.PasswordUtils;
 import net.schmizz.sshj.userauth.password.Resource;
 import net.schmizz.sshj.util.KeyUtil;
-import org.bouncycastle.util.BigIntegers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -300,7 +299,8 @@ public class OpenSSHKeyFileTest {
         final BigInteger expectedPrimeExponentQ = privateExponent.mod(rsaPrivateCrtKey.getPrimeQ().subtract(BigInteger.ONE));
         assertEquals("Prime Exponent Q not matched", expectedPrimeExponentQ, rsaPrivateCrtKey.getPrimeExponentQ());
 
-        final BigInteger expectedCoefficient = BigIntegers.modOddInverse(rsaPrivateCrtKey.getPrimeP(), rsaPrivateCrtKey.getPrimeQ());
+
+        final BigInteger expectedCoefficient = rsaPrivateCrtKey.getPrimeQ().modInverse(rsaPrivateCrtKey.getPrimeP());
         assertEquals("Prime CRT Coefficient not matched", expectedCoefficient, rsaPrivateCrtKey.getCrtCoefficient());
     }
 

--- a/src/test/java/net/schmizz/sshj/keyprovider/OpenSSHKeyFileTest.java
+++ b/src/test/java/net/schmizz/sshj/keyprovider/OpenSSHKeyFileTest.java
@@ -26,6 +26,7 @@ import net.schmizz.sshj.userauth.password.PasswordFinder;
 import net.schmizz.sshj.userauth.password.PasswordUtils;
 import net.schmizz.sshj.userauth.password.Resource;
 import net.schmizz.sshj.util.KeyUtil;
+import org.bouncycastle.util.BigIntegers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,6 +44,7 @@ import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPublicKey;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -103,7 +105,7 @@ public class OpenSSHKeyFileTest {
                 assertArrayEquals(new char[passwordChars.length], passwordChars);
             }
         }
-    };
+    }
 
     final PasswordFinder onlyGivesWhenReady = new PasswordFinder() {
         @Override
@@ -187,7 +189,7 @@ public class OpenSSHKeyFileTest {
     }
 
     @Test
-    public void shouldHaveCorrectFingerprintForECDSA256() throws IOException, GeneralSecurityException {
+    public void shouldHaveCorrectFingerprintForECDSA256() throws IOException {
         OpenSSHKeyFile keyFile = new OpenSSHKeyFile();
         keyFile.init(new File("src/test/resources/keytypes/test_ecdsa_nistp256"));
         String expected = "256 MD5:53:ae:db:ed:8f:2d:02:d4:d5:6c:24:bc:a4:66:88:79 root@itgcpkerberosstack-cbgateway-0-20151117031915 (ECDSA)\n";
@@ -197,7 +199,7 @@ public class OpenSSHKeyFileTest {
     }
 
     @Test
-    public void shouldHaveCorrectFingerprintForECDSA384() throws IOException, GeneralSecurityException {
+    public void shouldHaveCorrectFingerprintForECDSA384() throws IOException {
         OpenSSHKeyFile keyFile = new OpenSSHKeyFile();
         keyFile.init(new File("src/test/resources/keytypes/test_ecdsa_nistp384"));
         String expected = "384 MD5:ee:9b:82:d1:47:01:16:1b:27:da:f5:27:fd:b2:eb:e2";
@@ -207,7 +209,7 @@ public class OpenSSHKeyFileTest {
     }
 
     @Test
-    public void shouldHaveCorrectFingerprintForECDSA521() throws IOException, GeneralSecurityException {
+    public void shouldHaveCorrectFingerprintForECDSA521() throws IOException {
         OpenSSHKeyFile keyFile = new OpenSSHKeyFile();
         keyFile.init(new File("src/test/resources/keytypes/test_ecdsa_nistp521"));
         String expected = "521 MD5:22:e2:f4:3c:61:ae:e9:85:a1:4d:d9:6c:13:aa:eb:00";
@@ -272,6 +274,34 @@ public class OpenSSHKeyFileTest {
         keyFile.init(new File("src/test/resources/keyformats/rsa_opensshv1"));
         PrivateKey aPrivate = keyFile.getPrivate();
         assertThat(aPrivate.getAlgorithm(), equalTo("RSA"));
+    }
+
+    @Test
+    public void shouldLoadRSAPrivateCrtKeyAsOpenSSHV1() throws IOException {
+        final OpenSSHKeyV1KeyFile keyFile = new OpenSSHKeyV1KeyFile();
+        keyFile.init(new File("src/test/resources/keyformats/rsa_opensshv1"));
+        final PrivateKey privateKey = keyFile.getPrivate();
+        final PublicKey publicKey = keyFile.getPublic();
+
+        assertTrue(publicKey instanceof RSAPublicKey);
+        final RSAPublicKey rsaPublicKey = (RSAPublicKey) publicKey;
+
+        assertTrue(privateKey instanceof RSAPrivateCrtKey);
+        final RSAPrivateCrtKey rsaPrivateCrtKey = (RSAPrivateCrtKey) privateKey;
+
+        assertEquals("Public Key Exponent not matched", rsaPublicKey.getPublicExponent(), rsaPrivateCrtKey.getPublicExponent());
+        assertEquals("Public Key Modulus not matched", rsaPublicKey.getModulus(), rsaPrivateCrtKey.getModulus());
+
+        final BigInteger privateExponent = rsaPrivateCrtKey.getPrivateExponent();
+
+        final BigInteger expectedPrimeExponentP = privateExponent.mod(rsaPrivateCrtKey.getPrimeP().subtract(BigInteger.ONE));
+        assertEquals("Prime Exponent P not matched", expectedPrimeExponentP, rsaPrivateCrtKey.getPrimeExponentP());
+
+        final BigInteger expectedPrimeExponentQ = privateExponent.mod(rsaPrivateCrtKey.getPrimeQ().subtract(BigInteger.ONE));
+        assertEquals("Prime Exponent Q not matched", expectedPrimeExponentQ, rsaPrivateCrtKey.getPrimeExponentQ());
+
+        final BigInteger expectedCoefficient = BigIntegers.modOddInverse(rsaPrivateCrtKey.getPrimeP(), rsaPrivateCrtKey.getPrimeQ());
+        assertEquals("Prime CRT Coefficient not matched", expectedCoefficient, rsaPrivateCrtKey.getCrtCoefficient());
     }
 
     @Test


### PR DESCRIPTION
Key parsing in `OpenSSHKeyV1KeyFile` currently parses RSA Private Keys and returns an `RSAPrivateKeySpec` containing the modulus and private exponent. As a result of this approached, the BouncyCastle implementation of `RSAPrivateKey.getEncoded()` returns `0` for all other fields when serializing the the key to an ASN.1 encoded PrivateKeyInfo byte array.  This creates problems writing RSA Private Keys to PKCS8 PEM files as described in issue #705.

This pull request updates RSA Private Key parsing in `OpenSSHKeyV1KeyFile` to read and use the available elements of the RSA Private Key. Following [RFC 8017 Section 3.2](https://datatracker.ietf.org/doc/html/rfc8017#section-3.2), the updated approach calculates the Prime Exponent P and Prime Exponent Q values, then returns an `RSAPrivateCrtKeySpec` for conversion into a standard `java.security.PrivateKey`.  The implementation returns a complete representation of the ASN.1 encoded PrivateKeyInfo when calling `PrivateKey.getEncoded()`. This pull request includes a new unit test that compares the public exponent values against the parsed RSA Public Key, and also compares the expected computed exponents.