### PR TITLE
Update SSHClient to interrupt KeepAlive Thread when disconnecting

### DIFF
--- a/src/main/java/net/schmizz/sshj/SSHClient.java
+++ b/src/main/java/net/schmizz/sshj/SSHClient.java
@@ -15,6 +15,7 @@
  */
 package net.schmizz.sshj;
 
+import net.schmizz.keepalive.KeepAlive;
 import net.schmizz.sshj.common.*;
 import net.schmizz.sshj.connection.Connection;
 import net.schmizz.sshj.connection.ConnectionException;
@@ -424,6 +425,7 @@ public class SSHClient
     @Override
     public void disconnect()
             throws IOException {
+        conn.getKeepAlive().interrupt();
         for (LocalPortForwarder forwarder : forwarders) {
             try {
                 forwarder.close();
@@ -791,6 +793,10 @@ public class SSHClient
             throws IOException {
         super.onConnect();
         trans.init(getRemoteHostname(), getRemotePort(), getInputStream(), getOutputStream());
+        final KeepAlive keepAliveThread = conn.getKeepAlive();
+        if (keepAliveThread.isEnabled()) {
+            keepAliveThread.start();
+        }
         doKex();
     }
 

--- a/src/test/java/com/hierynomus/sshj/keepalive/KeepAliveThreadTerminationTest.java
+++ b/src/test/java/com/hierynomus/sshj/keepalive/KeepAliveThreadTerminationTest.java
@@ -15,54 +15,66 @@
  */
 package com.hierynomus.sshj.keepalive;
 
-import com.hierynomus.sshj.test.KnownFailingTests;
-import com.hierynomus.sshj.test.SlowTests;
 import com.hierynomus.sshj.test.SshFixture;
+import net.schmizz.keepalive.KeepAlive;
 import net.schmizz.keepalive.KeepAliveProvider;
 import net.schmizz.sshj.DefaultConfig;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.userauth.UserAuthException;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadInfo;
-import java.lang.management.ThreadMXBean;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class KeepAliveThreadTerminationTest {
+
+    private static final int KEEP_ALIVE_SECONDS = 1;
+
+    private static final long STOP_SLEEP = 1500;
 
     @Rule
     public SshFixture fixture = new SshFixture();
 
     @Test
-    @Category({SlowTests.class, KnownFailingTests.class})
-    public void shouldCorrectlyTerminateThreadOnDisconnect() throws IOException, InterruptedException {
-        DefaultConfig defaultConfig = new DefaultConfig();
-        defaultConfig.setKeepAliveProvider(KeepAliveProvider.KEEP_ALIVE);
-        for (int i = 0; i < 10; i++) {
-            SSHClient sshClient = fixture.setupClient(defaultConfig);
-            fixture.connectClient(sshClient);
-            sshClient.getConnection().getKeepAlive().setKeepAliveInterval(1);
-            try {
-                sshClient.authPassword("bad", "credentials");
-                fail("Should not auth.");
-            } catch (UserAuthException e) {
-                // OK
-            }
-            fixture.stopClient();
-            Thread.sleep(2000);
-        }
+    public void shouldNotStartThreadOnSetKeepAliveInterval() {
+        final SSHClient sshClient = setupClient();
 
-        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-        for (long l : threadMXBean.getAllThreadIds()) {
-            ThreadInfo threadInfo = threadMXBean.getThreadInfo(l);
-            if (threadInfo.getThreadName().equals("keep-alive") && threadInfo.getThreadState() != Thread.State.TERMINATED) {
-                fail("Found alive keep-alive thread in state " + threadInfo.getThreadState());
-            }
-        }
+        final KeepAlive keepAlive = sshClient.getConnection().getKeepAlive();
+        assertTrue(keepAlive.isDaemon());
+        assertFalse(keepAlive.isAlive());
+        assertEquals(Thread.State.NEW, keepAlive.getState());
+    }
+
+    @Test
+    public void shouldStartThreadOnConnectAndInterruptOnDisconnect() throws IOException, InterruptedException {
+        final SSHClient sshClient = setupClient();
+
+        final KeepAlive keepAlive = sshClient.getConnection().getKeepAlive();
+        assertTrue(keepAlive.isDaemon());
+        assertEquals(Thread.State.NEW, keepAlive.getState());
+
+        fixture.connectClient(sshClient);
+        assertEquals(Thread.State.TIMED_WAITING, keepAlive.getState());
+
+        assertThrows(UserAuthException.class, () -> sshClient.authPassword("bad", "credentials"));
+
+        fixture.stopClient();
+        Thread.sleep(STOP_SLEEP);
+
+        assertFalse(keepAlive.isAlive());
+        assertEquals(Thread.State.TERMINATED, keepAlive.getState());
+    }
+
+    private SSHClient setupClient() {
+        final DefaultConfig defaultConfig = new DefaultConfig();
+        defaultConfig.setKeepAliveProvider(KeepAliveProvider.KEEP_ALIVE);
+        final SSHClient sshClient = fixture.setupClient(defaultConfig);
+        sshClient.getConnection().getKeepAlive().setKeepAliveInterval(KEEP_ALIVE_SECONDS);
+        return sshClient;
     }
 }


### PR DESCRIPTION
The current `KeepAlive.setKeepAliveInterval()` method starts the Thread when invoked with an interval greater than zero. This behavior starts the KeepAlive Thread prior to establishing a connection, depending on when the caller invokes `setKeepAliveInterval()`. 

Neither the `ConnectionImpl` class nor the `SSHClient` class interrupt the KeepAlive Thread, resulting in continued looping inside of `KeepAlive.run()` even after disconnecting and closing `SSHClient` as described in issue #506.

This pull request changes the behavior of `KeepAlive.setKeepAliveInterval()` to avoid starting the Thread.  The `SSHClient.onConnect()` method checks whether the KeepAlive Thread is enabled and then calls `start()` to avoid unnecessary execution prior to a successful connection. The `SSHClient.disconnect()` method interrupts the KeepAlive Thread to ensure that it does not continue running. The `KeepAliveThreadTerminationTest` includes an additional method to verify the initial state of the KeepAlive Thread, as well as the state after connecting and disconnecting.