### PR TITLE
Add Thread naming based on remote socket address

### DIFF
--- a/src/main/java/com/hierynomus/sshj/common/RemoteAddressProvider.java
+++ b/src/main/java/com/hierynomus/sshj/common/RemoteAddressProvider.java
@@ -13,22 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package net.schmizz.keepalive;
+package com.hierynomus.sshj.common;
 
-import net.schmizz.sshj.common.Message;
-import net.schmizz.sshj.common.SSHPacket;
-import net.schmizz.sshj.connection.ConnectionImpl;
-import net.schmizz.sshj.transport.TransportException;
+import java.net.InetSocketAddress;
 
-final class Heartbeater
-        extends KeepAlive {
-
-    Heartbeater(ConnectionImpl conn) {
-        super(conn, "sshj-Heartbeater");
-    }
-
-    @Override
-    protected void doKeepAlive() throws TransportException {
-        conn.getTransport().write(new SSHPacket(Message.IGNORE));
-    }
+public interface RemoteAddressProvider {
+    /**
+     * Get Remote Socket Address associated with transport connection
+     *
+     * @return Remote Socket Address or null when not connected
+     */
+    InetSocketAddress getRemoteSocketAddress();
 }

--- a/src/main/java/com/hierynomus/sshj/common/ThreadNameProvider.java
+++ b/src/main/java/com/hierynomus/sshj/common/ThreadNameProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.common;
+
+import java.net.InetSocketAddress;
+
+public class ThreadNameProvider {
+    private static final String DISCONNECTED = "DISCONNECTED";
+
+    /**
+     * Set Thread Name prefixed with sshj followed by class and remote address when connected
+     *
+     * @param thread Class of Thread being named
+     * @param remoteAddressProvider Remote Address Provider associated with Thread
+     */
+    public static void setThreadName(final Thread thread, final RemoteAddressProvider remoteAddressProvider) {
+        final InetSocketAddress remoteSocketAddress = remoteAddressProvider.getRemoteSocketAddress();
+        final String address = remoteSocketAddress == null ? DISCONNECTED : remoteSocketAddress.toString();
+        final String threadName = String.format("sshj-%s-%s", thread.getClass().getSimpleName(), address);
+        thread.setName(threadName);
+    }
+}

--- a/src/main/java/net/schmizz/keepalive/KeepAliveRunner.java
+++ b/src/main/java/net/schmizz/keepalive/KeepAliveRunner.java
@@ -37,7 +37,7 @@ public class KeepAliveRunner extends KeepAlive {
             new LinkedList<Promise<SSHPacket, ConnectionException>>();
 
     KeepAliveRunner(ConnectionImpl conn) {
-        super(conn, "keep-alive");
+        super(conn, "sshj-KeepAliveRunner");
     }
 
     synchronized public int getMaxAliveCount() {

--- a/src/main/java/net/schmizz/sshj/SSHClient.java
+++ b/src/main/java/net/schmizz/sshj/SSHClient.java
@@ -16,6 +16,7 @@
 package net.schmizz.sshj;
 
 import net.schmizz.keepalive.KeepAlive;
+import com.hierynomus.sshj.common.ThreadNameProvider;
 import net.schmizz.sshj.common.*;
 import net.schmizz.sshj.connection.Connection;
 import net.schmizz.sshj.connection.ConnectionException;
@@ -56,6 +57,7 @@ import javax.security.auth.login.LoginContext;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.charset.Charset;
 import java.security.KeyPair;
@@ -444,6 +446,16 @@ public class SSHClient
     }
 
     /**
+     * Get Remote Socket Address from Transport
+     *
+     * @return Remote Socket Address or null when not connected
+     */
+    @Override
+    public InetSocketAddress getRemoteSocketAddress() {
+        return trans.getRemoteSocketAddress();
+    }
+
+    /**
      * Returns the character set used to communicate with the remote machine for certain strings (like paths).
      *
      * @return remote character set
@@ -795,6 +807,7 @@ public class SSHClient
         trans.init(getRemoteHostname(), getRemotePort(), getInputStream(), getOutputStream());
         final KeepAlive keepAliveThread = conn.getKeepAlive();
         if (keepAliveThread.isEnabled()) {
+            ThreadNameProvider.setThreadName(conn.getKeepAlive(), trans);
             keepAliveThread.start();
         }
         doKex();

--- a/src/main/java/net/schmizz/sshj/connection/channel/direct/SessionFactory.java
+++ b/src/main/java/net/schmizz/sshj/connection/channel/direct/SessionFactory.java
@@ -15,10 +15,11 @@
  */
 package net.schmizz.sshj.connection.channel.direct;
 
+import com.hierynomus.sshj.common.RemoteAddressProvider;
 import net.schmizz.sshj.common.SSHException;
 
 /** A factory interface for creating SSH {@link Session session channels}. */
-public interface SessionFactory {
+public interface SessionFactory extends RemoteAddressProvider {
 
     /**
      * Opens a {@code session} channel. The returned {@link Session} instance allows {@link Session#exec(String)
@@ -27,7 +28,7 @@ public interface SessionFactory {
      *
      * @return the opened {@code session} channel
      *
-     * @throws SSHException
+     * @throws SSHException Thrown on session initialization failures
      * @see Session
      */
     Session startSession()

--- a/src/main/java/net/schmizz/sshj/sftp/PacketReader.java
+++ b/src/main/java/net/schmizz/sshj/sftp/PacketReader.java
@@ -41,7 +41,7 @@ public class PacketReader extends Thread {
         this.engine = engine;
         log = engine.getLoggerFactory().getLogger(getClass());
         this.in = engine.getSubsystem().getInputStream();
-        setName("sftp reader");
+        setName("sshj-PacketReader");
         setDaemon(true);
     }
 

--- a/src/main/java/net/schmizz/sshj/sftp/SFTPEngine.java
+++ b/src/main/java/net/schmizz/sshj/sftp/SFTPEngine.java
@@ -15,6 +15,7 @@
  */
 package net.schmizz.sshj.sftp;
 
+import com.hierynomus.sshj.common.ThreadNameProvider;
 import net.schmizz.concurrent.Promise;
 import net.schmizz.sshj.common.IOUtils;
 import net.schmizz.sshj.common.LoggerFactory;
@@ -68,6 +69,7 @@ public class SFTPEngine
         sub = session.startSubsystem("sftp");
         out = sub.getOutputStream();
         reader = new PacketReader(this);
+        ThreadNameProvider.setThreadName(reader, ssh);
         pathHelper = new PathHelper(new PathHelper.Canonicalizer() {
             @Override
             public String canonicalize(String path)

--- a/src/main/java/net/schmizz/sshj/transport/Reader.java
+++ b/src/main/java/net/schmizz/sshj/transport/Reader.java
@@ -29,7 +29,7 @@ public final class Reader
     public Reader(TransportImpl trans) {
         this.trans = trans;
         log = trans.getConfig().getLoggerFactory().getLogger(getClass());
-        setName("reader");
+        setName("sshj-Reader");
         setDaemon(true);
     }
 

--- a/src/main/java/net/schmizz/sshj/transport/Transport.java
+++ b/src/main/java/net/schmizz/sshj/transport/Transport.java
@@ -15,6 +15,7 @@
  */
 package net.schmizz.sshj.transport;
 
+import com.hierynomus.sshj.common.RemoteAddressProvider;
 import com.hierynomus.sshj.key.KeyAlgorithm;
 import net.schmizz.sshj.Config;
 import net.schmizz.sshj.Service;
@@ -31,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 /** Transport layer of the SSH protocol. */
 public interface Transport
-        extends SSHPacketHandler {
+        extends SSHPacketHandler, RemoteAddressProvider {
 
     /**
      * Sets the host information and the streams to be used by this transport. Identification information is exchanged
@@ -208,7 +209,7 @@ public interface Transport
     /**
      * Specify a {@code listener} that will be notified upon disconnection.
      *
-     * @param listener
+     * @param listener Disconnect Listener to be configured
      */
     void setDisconnectListener(DisconnectListener listener);
 


### PR DESCRIPTION
This pull requests adds standard Thread names for the Transport `Reader`, the SFTP `PacketReader`, and the Connection `KeepAlive` Threads.  The implementation includes a `ThreadNameProvider` class to set the Thread name prefixed with `sshj` followed by the simple class name and the remote socket address.  The following provides an example name for the Transport `Reader` Thread:

```
sshj-Reader-localhost/127.0.0.1:22
```
This approach to thread naming provides association with SSHJ, identification of the Thread implementation, and the ability to distinguish between connections to different endpoints. These changes address the troubleshooting challenges described in issue #738.