### PR TITLE
Avoid setting SFTP rename flags below version 5

### DIFF
--- a/src/main/java/net/schmizz/sshj/sftp/SFTPEngine.java
+++ b/src/main/java/net/schmizz/sshj/sftp/SFTPEngine.java
@@ -235,14 +235,17 @@ public class SFTPEngine
         if (operativeVersion < 1)
             throw new SFTPException("RENAME is not supported in SFTPv" + operativeVersion);
 
-        long renameFlagMask = 0L;
-        for (RenameFlags flag : flags) {
-            renameFlagMask = renameFlagMask | flag.longValue();
+        final Request request = newRequest(PacketType.RENAME).putString(oldPath, sub.getRemoteCharset()).putString(newPath, sub.getRemoteCharset());
+        // SFTP Version 5 introduced rename flags according to Section 6.5 of the specification
+        if (operativeVersion >= 5) {
+            long renameFlagMask = 0L;
+            for (RenameFlags flag : flags) {
+                renameFlagMask = renameFlagMask | flag.longValue();
+            }
+            request.putUInt32(renameFlagMask);
         }
 
-        doRequest(
-                newRequest(PacketType.RENAME).putString(oldPath, sub.getRemoteCharset()).putString(newPath, sub.getRemoteCharset()).putUInt32(renameFlagMask)
-        ).ensureStatusPacketIsOK();
+        doRequest(request).ensureStatusPacketIsOK();
     }
 
     public String canonicalize(String path)


### PR DESCRIPTION
Pull request #652 introduced support for SFTP rename flags, which was released in SSHJ 0.32.0. The `SFTPEngine.rename()` method includes the rename flag mask without checking the SFTP operative version, causing communication issues described in #750 and #751.

The [SFTP Version 5 Section 6.5](https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-05#section-6.5) specification added support for rename flags, but previous versions such as [SFTP Version 3](https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-03#section-6.5) do not support rename flags.

This pull request changes the behavior and avoids appending the rename flag mask to the SFTP request packet for operative versions less than 5.