### PR TITLE
Add Codecov to GitHub workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,6 +24,8 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew check
+    - name: Codecov
+      uses: codecov/codecov-actions@v2
 
   integration:
     name: Integration test


### PR DESCRIPTION
This pull request adds the Codecov action to the GitHub build workflow to enable automated updates of code coverage status. The standard Gradle build generates the JaCoCo coverage report that provides that information Codecov requires.