### PR TITLE
Fix ReadAheadRemoteFileInputStream not reading the whole file if a buffer is too big

### DIFF
--- a/src/test/java/com/hierynomus/sshj/sftp/RemoteFileTest.java
+++ b/src/test/java/com/hierynomus/sshj/sftp/RemoteFileTest.java
@@ -17,22 +17,24 @@ package com.hierynomus.sshj.sftp;
 
 import com.hierynomus.sshj.test.SshFixture;
 import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.common.ByteArrayUtils;
 import net.schmizz.sshj.sftp.OpenMode;
 import net.schmizz.sshj.sftp.RemoteFile;
 import net.schmizz.sshj.sftp.SFTPEngine;
 import net.schmizz.sshj.sftp.SFTPException;
+import org.apache.sshd.common.util.io.IoUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
+import java.security.SecureRandom;
 import java.util.EnumSet;
 import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class RemoteFileTest {
@@ -173,5 +175,54 @@ public class RemoteFileTest {
         }
 
         assertThat("The written and received data should match", data, equalTo(test2));
+    }
+
+    @Test
+    public void shouldReadCorrectlyWhenWrappedInBufferedStream_FullSizeBuffer() throws IOException {
+        doTestShouldReadCorrectlyWhenWrappedInBufferedStream(1024 * 1024, 1024 * 1024);
+    }
+
+    @Test
+    public void shouldReadCorrectlyWhenWrappedInBufferedStream_HalfSizeBuffer() throws IOException {
+        doTestShouldReadCorrectlyWhenWrappedInBufferedStream(1024 * 1024, 512 * 1024);
+    }
+
+    @Test
+    public void shouldReadCorrectlyWhenWrappedInBufferedStream_QuarterSizeBuffer() throws IOException {
+        doTestShouldReadCorrectlyWhenWrappedInBufferedStream(1024 * 1024, 256 * 1024);
+    }
+
+    @Test
+    public void shouldReadCorrectlyWhenWrappedInBufferedStream_SmallSizeBuffer() throws IOException {
+        doTestShouldReadCorrectlyWhenWrappedInBufferedStream(1024 * 1024, 1024);
+    }
+
+    private void doTestShouldReadCorrectlyWhenWrappedInBufferedStream(int fileSize, int bufferSize) throws IOException {
+        SSHClient ssh = fixture.setupConnectedDefaultClient();
+        ssh.authPassword("test", "test");
+        SFTPEngine sftp = new SFTPEngine(ssh).init();
+
+        final byte[] expected = new byte[fileSize];
+        new SecureRandom(new byte[] { 31 }).nextBytes(expected);
+
+        File file = temp.newFile("shouldReadCorrectlyWhenWrappedInBufferedStream.bin");
+        try (OutputStream fStream = new FileOutputStream(file)) {
+            IoUtils.copy(new ByteArrayInputStream(expected), fStream);
+        }
+
+        RemoteFile rf = sftp.open(file.getPath());
+        final byte[] actual;
+        try (InputStream inputStream = new BufferedInputStream(
+                rf.new ReadAheadRemoteFileInputStream(10),
+                bufferSize)
+        ) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            IoUtils.copy(inputStream, baos, expected.length);
+            actual = baos.toByteArray();
+        }
+
+        assertEquals("The file should be fully read", expected.length, actual.length);
+        assertThat("The file should be read correctly",
+                ByteArrayUtils.equals(expected, 0, actual, 0, expected.length));
     }
 }


### PR DESCRIPTION
If an instance of ReadAheadRemoteFileInputStream before this change is wrapped into a BufferedInputStream with a big buffer, the SSH client requests big packets from the server. It turned out that if the server had sent a response smaller than requested, the client wouldn't have adjusted to decreased window size, and would have read the file incorrectly.

This change detects cases when the server is not able to fulfil client's requests. Since this change, the client adjusts the maximum request length, sends new read-ahead requests, and starts to ignore all read-ahead requests sent earlier.

Just specifying some allegedly small constant buffer size wouldn't have helped in all possible cases. There is no way to explicitly get the maximum request length inside a client. All that limits differ from server to server. For instance, OpenSSH defines SFTP_MAX_MSG_LENGTH as 256 * 1024. Apache SSHD defines MAX_READDATA_PACKET_LENGTH as 63 * 1024, and it allows to redefine that size.

Interestingly, a similar issue #183 was fixed many years ago, but the bug was actually in the code introduced for that fix.