### PR TITLE
Remove jzlib dependency

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -95,7 +95,7 @@ If you need something that is not included, it shouldn't be too hard to add (do 
 http://ssh-comparison.quendi.de/comparison.html[SSH Implementation Comparison]
 
 == Dependencies
-Java 6+. http://www.slf4j.org/download.html[slf4j] is required. http://www.bouncycastle.org/java.html[bouncycastle] is highly recommended and required for using some of the crypto algorithms.
+Java 7+. http://www.slf4j.org/download.html[slf4j] is required. http://www.bouncycastle.org/java.html[bouncycastle] is highly recommended and required for using some of the crypto algorithms.
 
 == Reporting bugs
 Issue tracker: https://github.com/hierynomus/sshj/issues

--- a/README.adoc
+++ b/README.adoc
@@ -95,7 +95,7 @@ If you need something that is not included, it shouldn't be too hard to add (do 
 http://ssh-comparison.quendi.de/comparison.html[SSH Implementation Comparison]
 
 == Dependencies
-Java 6+. http://www.slf4j.org/download.html[slf4j] is required. http://www.bouncycastle.org/java.html[bouncycastle] is highly recommended and required for using some of the crypto algorithms. http://www.jcraft.com/jzlib/[jzlib] is required for using zlib compression.
+Java 6+. http://www.slf4j.org/download.html[slf4j] is required. http://www.bouncycastle.org/java.html[bouncycastle] is highly recommended and required for using some of the crypto algorithms.
 
 == Reporting bugs
 Issue tracker: https://github.com/hierynomus/sshj/issues

--- a/build-publishing.gradle
+++ b/build-publishing.gradle
@@ -23,7 +23,6 @@ dependencies {
   compile "org.slf4j:slf4j-api:1.7.7"
   compile "org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion"
   compile "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
-  compile "com.jcraft:jzlib:1.1.3"
 
   testCompile "junit:junit:4.11"
   testCompile "org.mockito:mockito-core:1.9.5"

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ dependencies {
   implementation "org.slf4j:slf4j-api:1.7.36"
   implementation "org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion"
   implementation "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
-  implementation "com.jcraft:jzlib:1.1.3"
   implementation "com.hierynomus:asn-one:0.6.0"
 
   implementation "net.i2p.crypto:eddsa:0.3.0"

--- a/src/main/java/net/schmizz/sshj/transport/compression/ZlibCompression.java
+++ b/src/main/java/net/schmizz/sshj/transport/compression/ZlibCompression.java
@@ -15,18 +15,16 @@
  */
 package net.schmizz.sshj.transport.compression;
 
-import com.jcraft.jzlib.Deflater;
-import com.jcraft.jzlib.GZIPException;
-import com.jcraft.jzlib.Inflater;
-import com.jcraft.jzlib.JZlib;
+import java.util.zip.DataFormatException;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
 import net.schmizz.sshj.common.Buffer;
 import net.schmizz.sshj.common.DisconnectReason;
-import net.schmizz.sshj.common.SSHRuntimeException;
 import net.schmizz.sshj.transport.TransportException;
+import net.schmizz.sshj.transport.compression.Compression;
 
-/** ZLib based Compression. */
-public class ZlibCompression
-        implements Compression {
+public class ZlibCompression implements Compression {
 
     /** Named factory for the ZLib Compression. */
     public static class Factory
@@ -52,19 +50,15 @@ public class ZlibCompression
 
     @Override
     public void init(Mode mode) {
-        try {
-            switch (mode) {
-                case DEFLATE:
-                    deflater = new Deflater(JZlib.Z_DEFAULT_COMPRESSION);
-                    break;
-                case INFLATE:
-                    inflater = new Inflater();
-                    break;
-                default:
-                    assert false;
-            }
-        } catch (GZIPException gze) {
-
+        switch (mode) {
+            case DEFLATE:
+                deflater = new Deflater(Deflater.DEFAULT_COMPRESSION);
+                break;
+            case INFLATE:
+                inflater = new Inflater();
+                break;
+            default:
+                assert false;
         }
     }
 
@@ -75,43 +69,28 @@ public class ZlibCompression
 
     @Override
     public void compress(Buffer buffer) {
-        deflater.setNextIn(buffer.array());
-        deflater.setNextInIndex(buffer.rpos());
-        deflater.setAvailIn(buffer.available());
+        deflater.setInput(buffer.array(), buffer.rpos(), buffer.available());
         buffer.wpos(buffer.rpos());
         do {
-            deflater.setNextOut(tempBuf);
-            deflater.setNextOutIndex(0);
-            deflater.setAvailOut(BUF_SIZE);
-            final int status = deflater.deflate(JZlib.Z_PARTIAL_FLUSH);
-            if (status == JZlib.Z_OK) {
-                buffer.putRawBytes(tempBuf, 0, BUF_SIZE - deflater.getAvailOut());
-            } else {
-                throw new SSHRuntimeException("compress: deflate returned " + status);
-            }
-        } while (deflater.getAvailOut() == 0);
+            final int len = deflater.deflate(tempBuf, 0, BUF_SIZE, Deflater.SYNC_FLUSH);
+            buffer.putRawBytes(tempBuf, 0, len);
+        } while (!deflater.needsInput());
     }
-
 
     @Override
     public void uncompress(Buffer from, Buffer to)
             throws TransportException {
-        inflater.setNextIn(from.array());
-        inflater.setNextInIndex(from.rpos());
-        inflater.setAvailIn(from.available());
+        inflater.setInput(from.array(), from.rpos(), from.available());
         while (true) {
-            inflater.setNextOut(tempBuf);
-            inflater.setNextOutIndex(0);
-            inflater.setAvailOut(BUF_SIZE);
-            final int status = inflater.inflate(JZlib.Z_PARTIAL_FLUSH);
-            switch (status) {
-                case JZlib.Z_OK:
-                    to.putRawBytes(tempBuf, 0, BUF_SIZE - inflater.getAvailOut());
-                    break;
-                case JZlib.Z_BUF_ERROR:
+            try {
+                int len = inflater.inflate(tempBuf, 0, BUF_SIZE);
+                if(len > 0) {
+                    to.putRawBytes(tempBuf, 0, len);
+                } else {
                     return;
-                default:
-                    throw new TransportException(DisconnectReason.COMPRESSION_ERROR, "uncompress: inflate returned " + status);
+                }
+            } catch (DataFormatException e) {
+                throw new TransportException(DisconnectReason.COMPRESSION_ERROR, "uncompress: inflate returned " + e.getMessage());
             }
         }
     }


### PR DESCRIPTION
The JRE already contains a gzip implementation in `java.util.zip.*`, so we should be able to use that rather than relying on the external jCraft library.