### PR TITLE
Throw IOE instead of NPE if OpenSSHKeyV1KeyFile reads an empty file

### DIFF
--- a/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
@@ -218,6 +218,9 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
         while (line != null && !line.startsWith(BEGIN)) {
             line = reader.readLine();
         }
+        if (line == null) {
+            return false;
+        }
         line = line.substring(BEGIN.length());
         return line.startsWith(OPENSSH_PRIVATE_KEY);
     }

--- a/src/test/java/net/schmizz/sshj/keyprovider/OpenSSHKeyFileTest.java
+++ b/src/test/java/net/schmizz/sshj/keyprovider/OpenSSHKeyFileTest.java
@@ -39,6 +39,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.io.StringReader;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
@@ -441,6 +442,14 @@ public class OpenSSHKeyFileTest {
                      corruptedKeyFile.getPrivate());
         assertEquals(initialKeyFile.getPublic(),
                      corruptedKeyFile.getPublic());
+    }
+
+    @Test
+    public void emptyPrivateKey() {
+        FileKeyProvider keyProvider = new OpenSSHKeyV1KeyFile();
+        keyProvider.init(new StringReader(""));
+
+        assertThrows("This key is not in 'openssh-key-v1' format", IOException.class, keyProvider::getPrivate);
     }
 
     @Before


### PR DESCRIPTION
There is a contract that `FileKeyProvider.readKey` throws an IOException if something goes wrong. Throwing an NPE is not expected by API users. Also, it is much more difficult to find out if the NPE is thrown due to a broken key file, or due to an internal bug.