### PR TITLE
Added SFTP file transfer resume support on both PUT and GET. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,12 @@ license {
   mapping {
     java = 'SLASHSTAR_STYLE'
   }
-  excludes(['**/djb/Curve25519.java', '**/sshj/common/Base64.java', '**/com/hierynomus/sshj/userauth/keyprovider/bcrypt/*.java', '**/test/resources/files/test_file*.txt'])
+  excludes([
+    '**/djb/Curve25519.java',
+    '**/sshj/common/Base64.java',
+    '**/com/hierynomus/sshj/userauth/keyprovider/bcrypt/*.java',
+    '**/files/test_file_*.txt',
+  ])
 }
 
 if (!JavaVersion.current().isJava9Compatible()) {

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ license {
   mapping {
     java = 'SLASHSTAR_STYLE'
   }
-  excludes(['**/djb/Curve25519.java', '**/sshj/common/Base64.java', '**/com/hierynomus/sshj/userauth/keyprovider/bcrypt/*.java'])
+  excludes(['**/djb/Curve25519.java', '**/sshj/common/Base64.java', '**/com/hierynomus/sshj/userauth/keyprovider/bcrypt/*.java', '**/test/resources/files/test_file*.txt'])
 }
 
 if (!JavaVersion.current().isJava9Compatible()) {

--- a/src/main/java/net/schmizz/sshj/sftp/RemoteFile.java
+++ b/src/main/java/net/schmizz/sshj/sftp/RemoteFile.java
@@ -259,7 +259,16 @@ public class RemoteFile
         private boolean eof;
 
         public ReadAheadRemoteFileInputStream(int maxUnconfirmedReads) {
-            this(maxUnconfirmedReads, 0L, -1L);
+            this(maxUnconfirmedReads, 0L);
+        }
+        
+        /**
+         *
+         * @param maxUnconfirmedReads Maximum number of unconfirmed requests to send
+         * @param fileOffset Initial offset in file to read from
+         */
+        public ReadAheadRemoteFileInputStream(int maxUnconfirmedReads, long fileOffset) {
+            this(maxUnconfirmedReads, fileOffset, -1L);
         }
 
         /**

--- a/src/main/java/net/schmizz/sshj/sftp/SFTPClient.java
+++ b/src/main/java/net/schmizz/sshj/sftp/SFTPClient.java
@@ -233,9 +233,9 @@ public class SFTPClient
         xfer.download(source, dest);
     }
     
-    public void get(String source, String dest, boolean resume)
+    public void get(String source, String dest, long byteOffset)
             throws IOException {
-        xfer.download(source, dest, resume);
+        xfer.download(source, dest, byteOffset);
     }
 
     public void put(String source, String dest)
@@ -243,9 +243,9 @@ public class SFTPClient
         xfer.upload(source, dest);
     }
 
-    public void put(String source, String dest, boolean resume)
+    public void put(String source, String dest, long byteOffset)
             throws IOException {
-        xfer.upload(source, dest, resume);
+        xfer.upload(source, dest, byteOffset);
     }
 
     public void get(String source, LocalDestFile dest)
@@ -253,9 +253,9 @@ public class SFTPClient
         xfer.download(source, dest);
     }
     
-    public void get(String source, LocalDestFile dest, boolean resume)
+    public void get(String source, LocalDestFile dest, long byteOffset)
             throws IOException {
-        xfer.download(source, dest, resume);
+        xfer.download(source, dest, byteOffset);
     }
 
     public void put(LocalSourceFile source, String dest)
@@ -263,9 +263,9 @@ public class SFTPClient
         xfer.upload(source, dest);
     }
     
-    public void put(LocalSourceFile source, String dest, boolean resume)
+    public void put(LocalSourceFile source, String dest, long byteOffset)
             throws IOException {
-        xfer.upload(source, dest, resume);
+        xfer.upload(source, dest, byteOffset);
     }
 
     @Override

--- a/src/main/java/net/schmizz/sshj/sftp/SFTPClient.java
+++ b/src/main/java/net/schmizz/sshj/sftp/SFTPClient.java
@@ -232,20 +232,40 @@ public class SFTPClient
             throws IOException {
         xfer.download(source, dest);
     }
+    
+    public void get(String source, String dest, boolean resume)
+            throws IOException {
+        xfer.download(source, dest, resume);
+    }
 
     public void put(String source, String dest)
             throws IOException {
         xfer.upload(source, dest);
     }
 
+    public void put(String source, String dest, boolean resume)
+            throws IOException {
+        xfer.upload(source, dest, resume);
+    }
+
     public void get(String source, LocalDestFile dest)
             throws IOException {
         xfer.download(source, dest);
+    }
+    
+    public void get(String source, LocalDestFile dest, boolean resume)
+            throws IOException {
+        xfer.download(source, dest, resume);
     }
 
     public void put(LocalSourceFile source, String dest)
             throws IOException {
         xfer.upload(source, dest);
+    }
+    
+    public void put(LocalSourceFile source, String dest, boolean resume)
+            throws IOException {
+        xfer.upload(source, dest, resume);
     }
 
     @Override

--- a/src/main/java/net/schmizz/sshj/sftp/SFTPFileTransfer.java
+++ b/src/main/java/net/schmizz/sshj/sftp/SFTPFileTransfer.java
@@ -124,6 +124,7 @@ public class SFTPFileTransfer
                 case UNKNOWN:
                     log.warn("Server did not supply information about the type of file at `{}` " +
                                      "-- assuming it is a regular file!", remote.getPath());
+                    // fall through
                 case REGULAR:
                     adjustedFile = downloadFile(listener.file(remote.getName(), remote.getAttributes().getSize()), remote, local, resume);
                     break;

--- a/src/main/java/net/schmizz/sshj/sftp/SFTPFileTransfer.java
+++ b/src/main/java/net/schmizz/sshj/sftp/SFTPFileTransfer.java
@@ -159,8 +159,8 @@ public class SFTPFileTransfer
             final RemoteFile rf = engine.open(remote.getPath());
             long byteOffset = 0;
             try {
-                if (resume && adjusted.getLength() != 0 && adjusted.getLength() < remote.getAttributes().getSize()) {
-                    // resume requested AND there's already at least one byte there AND the existing file isn't as long as the incoming remote
+                if (resume && adjusted.getLength() != 0 && adjusted.getLength() <= remote.getAttributes().getSize()) {
+                    // resume requested AND there's already at least one byte there AND the existing file isn't longer than the incoming remote
                     // we can honor the request to resume by setting the offset
                     byteOffset = adjusted.getLength();
                 }

--- a/src/main/java/net/schmizz/sshj/xfer/FileSystemFile.java
+++ b/src/main/java/net/schmizz/sshj/xfer/FileSystemFile.java
@@ -71,7 +71,13 @@ public class FileSystemFile
     @Override
     public OutputStream getOutputStream()
             throws IOException {
-        return new FileOutputStream(file);
+        return getOutputStream(false);
+    }
+    
+    @Override
+    public OutputStream getOutputStream(boolean append)
+            throws IOException {
+        return new FileOutputStream(file, append);
     }
 
     @Override

--- a/src/main/java/net/schmizz/sshj/xfer/FileTransfer.java
+++ b/src/main/java/net/schmizz/sshj/xfer/FileTransfer.java
@@ -32,6 +32,19 @@ public interface FileTransfer {
             throws IOException;
 
     /**
+     * This is meant to delegate to {@link #upload(LocalSourceFile, String)} with the {@code localPath} wrapped as e.g.
+     * a {@link FileSystemFile}. Attempts to resume with the {@code resume} flag.
+     *
+     * @param localPath
+     * @param remotePath
+     * @param resume
+     *
+     * @throws IOException
+     */
+    void upload(String localPath, String remotePath, boolean resume)
+            throws IOException;
+
+    /**
      * This is meant to delegate to {@link #download(String, LocalDestFile)} with the {@code localPath} wrapped as e.g.
      * a {@link FileSystemFile}.
      *
@@ -41,6 +54,19 @@ public interface FileTransfer {
      * @throws IOException
      */
     void download(String remotePath, String localPath)
+            throws IOException;
+
+    /**
+     * This is meant to delegate to {@link #download(String, LocalDestFile)} with the {@code localPath} wrapped as e.g.
+     * a {@link FileSystemFile}. Attempts to resume with the {@code resume} flag.
+     *
+     * @param localPath
+     * @param remotePath
+     * @param resume
+     *
+     * @throws IOException
+     */
+    void download(String remotePath, String localPath, boolean resume)
             throws IOException;
 
     /**
@@ -55,6 +81,18 @@ public interface FileTransfer {
             throws IOException;
 
     /**
+     * Upload {@code localFile} to {@code remotePath}. Attempts to resume with the {@code resume} flag.
+     *
+     * @param localFile
+     * @param remotePath
+     * @param resume
+     *
+     * @throws IOException
+     */
+    void upload(LocalSourceFile localFile, String remotePath, boolean resume)
+            throws IOException;
+
+    /**
      * Download {@code remotePath} to {@code localFile}.
      *
      * @param localFile
@@ -63,6 +101,18 @@ public interface FileTransfer {
      * @throws IOException
      */
     void download(String remotePath, LocalDestFile localFile)
+            throws IOException;
+
+    /**
+     * Download {@code remotePath} to {@code localFile}. Attempts to resume with the {@code resume} flag.
+     *
+     * @param localFile
+     * @param remotePath
+     * @param resume
+     *
+     * @throws IOException
+     */
+    void download(String remotePath, LocalDestFile localFile, boolean resume)
             throws IOException;
 
     TransferListener getTransferListener();

--- a/src/main/java/net/schmizz/sshj/xfer/FileTransfer.java
+++ b/src/main/java/net/schmizz/sshj/xfer/FileTransfer.java
@@ -33,15 +33,15 @@ public interface FileTransfer {
 
     /**
      * This is meant to delegate to {@link #upload(LocalSourceFile, String)} with the {@code localPath} wrapped as e.g.
-     * a {@link FileSystemFile}. Attempts to resume with the {@code resume} flag.
+     * a {@link FileSystemFile}. Appends to existing if {@code byteOffset} &gt; 0.
      *
      * @param localPath
      * @param remotePath
-     * @param resume
+     * @param byteOffset
      *
      * @throws IOException
      */
-    void upload(String localPath, String remotePath, boolean resume)
+    void upload(String localPath, String remotePath, long byteOffset)
             throws IOException;
 
     /**
@@ -58,15 +58,15 @@ public interface FileTransfer {
 
     /**
      * This is meant to delegate to {@link #download(String, LocalDestFile)} with the {@code localPath} wrapped as e.g.
-     * a {@link FileSystemFile}. Attempts to resume with the {@code resume} flag.
+     * a {@link FileSystemFile}. Appends to existing if {@code byteOffset} &gt; 0.
      *
      * @param localPath
      * @param remotePath
-     * @param resume
+     * @param byteOffset
      *
      * @throws IOException
      */
-    void download(String remotePath, String localPath, boolean resume)
+    void download(String remotePath, String localPath, long byteOffset)
             throws IOException;
 
     /**
@@ -81,15 +81,15 @@ public interface FileTransfer {
             throws IOException;
 
     /**
-     * Upload {@code localFile} to {@code remotePath}. Attempts to resume with the {@code resume} flag.
+     * Upload {@code localFile} to {@code remotePath}. Appends to existing if {@code byteOffset} &gt; 0.
      *
      * @param localFile
      * @param remotePath
-     * @param resume
+     * @param byteOffset
      *
      * @throws IOException
      */
-    void upload(LocalSourceFile localFile, String remotePath, boolean resume)
+    void upload(LocalSourceFile localFile, String remotePath, long byteOffset)
             throws IOException;
 
     /**
@@ -104,15 +104,15 @@ public interface FileTransfer {
             throws IOException;
 
     /**
-     * Download {@code remotePath} to {@code localFile}. Attempts to resume with the {@code resume} flag.
+     * Download {@code remotePath} to {@code localFile}. Appends to existing if {@code byteOffset} &gt; 0.
      *
      * @param localFile
      * @param remotePath
-     * @param resume
+     * @param byteOffset
      *
      * @throws IOException
      */
-    void download(String remotePath, LocalDestFile localFile, boolean resume)
+    void download(String remotePath, LocalDestFile localFile, long byteOffset)
             throws IOException;
 
     TransferListener getTransferListener();

--- a/src/main/java/net/schmizz/sshj/xfer/LocalDestFile.java
+++ b/src/main/java/net/schmizz/sshj/xfer/LocalDestFile.java
@@ -20,7 +20,12 @@ import java.io.OutputStream;
 
 public interface LocalDestFile {
 
+    long getLength();
+
     OutputStream getOutputStream()
+            throws IOException;
+    
+    OutputStream getOutputStream(boolean append)
             throws IOException;
 
     /** @return A child file/directory of this directory with given {@code name}. */

--- a/src/main/java/net/schmizz/sshj/xfer/scp/SCPFileTransfer.java
+++ b/src/main/java/net/schmizz/sshj/xfer/scp/SCPFileTransfer.java
@@ -52,24 +52,49 @@ public class SCPFileTransfer
     @Override
     public void upload(String localPath, String remotePath)
             throws IOException {
-        newSCPUploadClient().copy(new FileSystemFile(localPath), remotePath);
+        upload(localPath, remotePath, false);
+    }
+
+    @Override
+    public void upload(String localFile, String remotePath, boolean resume)
+            throws IOException {
+        upload(new FileSystemFile(localFile), remotePath, resume);
     }
 
     @Override
     public void download(String remotePath, String localPath)
             throws IOException {
-        download(remotePath, new FileSystemFile(localPath));
+        download(remotePath, localPath, false);
+    }
+
+    @Override
+    public void download(String remotePath, String localPath, boolean resume) throws IOException {
+        download(remotePath, new FileSystemFile(localPath), resume);
     }
 
     @Override
     public void download(String remotePath, LocalDestFile localFile)
             throws IOException {
+        download(remotePath, localFile, false);
+    }
+    
+    @Override
+    public void download(String remotePath, LocalDestFile localFile, boolean resume)
+            throws IOException {
+        checkResumeSupport(resume);
         newSCPDownloadClient().copy(remotePath, localFile);
     }
 
     @Override
     public void upload(LocalSourceFile localFile, String remotePath)
             throws IOException {
+        upload(localFile, remotePath, false);
+    }
+
+    @Override
+    public void upload(LocalSourceFile localFile, String remotePath, boolean resume)
+            throws IOException {
+        checkResumeSupport(resume);
         newSCPUploadClient().copy(localFile, remotePath);
     }
 
@@ -78,5 +103,14 @@ public class SCPFileTransfer
             this.bandwidthLimit = limit;
         }
         return this;
+    }
+    
+    private void checkResumeSupport(boolean resume) throws IOException {
+        // TODO - implement resume on SCP. Not needed for my use case but the FileTransfer interface will expose it to other users.
+        if (resume) {
+            log.warn("SCP does not support resuming file transfers. Falling back to replacement.");
+            // TODO - more preferable to throw exception until it is implemented?
+//            throw new IOException("SCP does not support resuming file transfers. Falling back to replacement.");
+        } 
     }
 }

--- a/src/main/java/net/schmizz/sshj/xfer/scp/SCPFileTransfer.java
+++ b/src/main/java/net/schmizz/sshj/xfer/scp/SCPFileTransfer.java
@@ -52,49 +52,49 @@ public class SCPFileTransfer
     @Override
     public void upload(String localPath, String remotePath)
             throws IOException {
-        upload(localPath, remotePath, false);
+        upload(localPath, remotePath, 0);
     }
 
     @Override
-    public void upload(String localFile, String remotePath, boolean resume)
+    public void upload(String localFile, String remotePath, long byteOffset)
             throws IOException {
-        upload(new FileSystemFile(localFile), remotePath, resume);
+        upload(new FileSystemFile(localFile), remotePath, byteOffset);
     }
 
     @Override
     public void download(String remotePath, String localPath)
             throws IOException {
-        download(remotePath, localPath, false);
+        download(remotePath, localPath, 0);
     }
 
     @Override
-    public void download(String remotePath, String localPath, boolean resume) throws IOException {
-        download(remotePath, new FileSystemFile(localPath), resume);
+    public void download(String remotePath, String localPath, long byteOffset) throws IOException {
+        download(remotePath, new FileSystemFile(localPath), byteOffset);
     }
 
     @Override
     public void download(String remotePath, LocalDestFile localFile)
             throws IOException {
-        download(remotePath, localFile, false);
+        download(remotePath, localFile, 0);
     }
     
     @Override
-    public void download(String remotePath, LocalDestFile localFile, boolean resume)
+    public void download(String remotePath, LocalDestFile localFile, long byteOffset)
             throws IOException {
-        checkResumeSupport(resume);
+        checkByteOffsetSupport(byteOffset);
         newSCPDownloadClient().copy(remotePath, localFile);
     }
 
     @Override
     public void upload(LocalSourceFile localFile, String remotePath)
             throws IOException {
-        upload(localFile, remotePath, false);
+        upload(localFile, remotePath, 0);
     }
 
     @Override
-    public void upload(LocalSourceFile localFile, String remotePath, boolean resume)
+    public void upload(LocalSourceFile localFile, String remotePath, long byteOffset)
             throws IOException {
-        checkResumeSupport(resume);
+        checkByteOffsetSupport(byteOffset);
         newSCPUploadClient().copy(localFile, remotePath);
     }
 
@@ -105,10 +105,10 @@ public class SCPFileTransfer
         return this;
     }
     
-    private void checkResumeSupport(boolean resume) throws IOException {
-        // TODO - implement resume on SCP, if possible.
-        if (resume) {
-            throw new SCPException("Resuming SCP file transfers is not supported.");
+    private void checkByteOffsetSupport(long byteOffset) throws IOException {
+        // TODO - implement byte offsets on SCP, if possible.
+        if (byteOffset > 0) {
+            throw new SCPException("Byte offset on SCP file transfers is not supported.");
         } 
     }
 }

--- a/src/main/java/net/schmizz/sshj/xfer/scp/SCPFileTransfer.java
+++ b/src/main/java/net/schmizz/sshj/xfer/scp/SCPFileTransfer.java
@@ -106,11 +106,9 @@ public class SCPFileTransfer
     }
     
     private void checkResumeSupport(boolean resume) throws IOException {
-        // TODO - implement resume on SCP. Not needed for my use case but the FileTransfer interface will expose it to other users.
+        // TODO - implement resume on SCP, if possible.
         if (resume) {
-            log.warn("SCP does not support resuming file transfers. Falling back to replacement.");
-            // TODO - more preferable to throw exception until it is implemented?
-//            throw new IOException("SCP does not support resuming file transfers. Falling back to replacement.");
+            throw new SCPException("Resuming SCP file transfers is not supported.");
         } 
     }
 }

--- a/src/test/java/com/hierynomus/sshj/test/util/FileUtil.java
+++ b/src/test/java/com/hierynomus/sshj/test/util/FileUtil.java
@@ -39,4 +39,8 @@ public class FileUtil {
             IOUtils.closeQuietly(fileInputStream);
         }
     }
+    
+    public static boolean compareFileContents(File f1, File f2) throws IOException {
+        return readFromFile(f1).equals(readFromFile(f2));
+    }
 }

--- a/src/test/java/net/schmizz/sshj/sftp/SFTPFileTransferTest.java
+++ b/src/test/java/net/schmizz/sshj/sftp/SFTPFileTransferTest.java
@@ -75,15 +75,15 @@ public class SFTPFileTransferTest {
         }
     }
     
-    private void performDownload(boolean resume) throws IOException {
+    private void performDownload(long byteOffset) throws IOException {
         assertTrue(listener.getBytesTransferred() == 0);
         
         long expectedBytes = 0;
         
         // Using the resume param this way to call the different entry points into the FileTransfer interface
-        if (resume) {
+        if (byteOffset > 0) {
             expectedBytes = sourceFile.length() - targetFile.length(); // only the difference between what is there and what should be
-            xfer.download(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath(), true);
+            xfer.download(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath(), byteOffset);
         } else {
             expectedBytes = sourceFile.length(); // the entire source file should be transferred
             xfer.download(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath());
@@ -93,15 +93,15 @@ public class SFTPFileTransferTest {
         assertTrue(listener.getBytesTransferred() == expectedBytes);
     }
     
-    private void performUpload(boolean resume) throws IOException {
+    private void performUpload(long byteOffset) throws IOException {
         assertTrue(listener.getBytesTransferred() == 0);
         
         long expectedBytes = 0;
         
         // Using the resume param this way to call the different entry points into the FileTransfer interface
-        if (resume) {
+        if (byteOffset > 0) {
             expectedBytes = sourceFile.length() - targetFile.length(); // only the difference between what is there and what should be
-            xfer.upload(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath(), true);
+            xfer.upload(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath(), byteOffset);
         } else {
             expectedBytes = sourceFile.length(); // the entire source file should be transferred
             xfer.upload(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath());
@@ -112,52 +112,52 @@ public class SFTPFileTransferTest {
     
     @Test
     public void testDownload() throws IOException {
-        performDownload(false);
+        performDownload(0);
     }
     
     @Test
     public void testDownloadResumePartial() throws IOException {
         FileUtil.writeToFile(targetFile, FileUtil.readFromFile(partialFile));
         assertFalse(FileUtil.compareFileContents(sourceFile, targetFile));
-        performDownload(true);
+        performDownload(targetFile.length());
     }
     
     @Test
     public void testDownloadResumeNothing() throws IOException {
         assertFalse(targetFile.exists());
-        performDownload(true);
+        performDownload(targetFile.length());
     }
     
     @Test
     public void testDownloadResumePreviouslyCompleted() throws IOException {
         FileUtil.writeToFile(targetFile, FileUtil.readFromFile(sourceFile));
         assertTrue(FileUtil.compareFileContents(sourceFile, targetFile));
-        performDownload(true);
+        performDownload(targetFile.length());
     }
     
     @Test
     public void testUpload() throws IOException {
-        performUpload(false);
+        performUpload(0);
     }
     
     @Test
     public void testUploadResumePartial() throws IOException {
         FileUtil.writeToFile(targetFile, FileUtil.readFromFile(partialFile));
         assertFalse(FileUtil.compareFileContents(sourceFile, targetFile));
-        performUpload(true);
+        performUpload(targetFile.length());
     }
     
     @Test
     public void testUploadResumeNothing() throws IOException {
         assertFalse(targetFile.exists());
-        performUpload(true);
+        performUpload(targetFile.length());
     }
     
     @Test
     public void testUploadResumePreviouslyCompleted() throws IOException {
         FileUtil.writeToFile(targetFile, FileUtil.readFromFile(sourceFile));
         assertTrue(FileUtil.compareFileContents(sourceFile, targetFile));
-        performUpload(true);
+        performUpload(targetFile.length());
     }
     
     public class ByteCounter implements TransferListener, StreamCopier.Listener {

--- a/src/test/java/net/schmizz/sshj/sftp/SFTPFileTransferTest.java
+++ b/src/test/java/net/schmizz/sshj/sftp/SFTPFileTransferTest.java
@@ -1,6 +1,17 @@
 /*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package net.schmizz.sshj.sftp;
 
@@ -10,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import net.schmizz.sshj.SSHClient;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/net/schmizz/sshj/sftp/SFTPFileTransferTest.java
+++ b/src/test/java/net/schmizz/sshj/sftp/SFTPFileTransferTest.java
@@ -1,0 +1,138 @@
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ */
+package net.schmizz.sshj.sftp;
+
+import com.hierynomus.sshj.test.SshFixture;
+import com.hierynomus.sshj.test.util.FileUtil;
+import java.io.File;
+import java.io.IOException;
+import net.schmizz.sshj.SSHClient;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ * @author Brent Tyler
+ */
+public class SFTPFileTransferTest {
+    
+    public static final String TARGET_FILE_NAME = "target.txt";
+    
+    File targetDir;
+    File targetFile;
+    File sourceFile;
+    
+    File partialFile;
+    
+    SSHClient sshClient;
+    SFTPFileTransfer xfer;
+    
+    @Rule
+    public SshFixture fixture = new SshFixture();
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Before
+    public void init() throws IOException {
+        targetDir   = tempFolder.newFolder();
+        targetFile  = new File(targetDir, TARGET_FILE_NAME);
+        sourceFile  = new File("src/test/resources/files/test_file_full.txt");
+        
+        partialFile = new File("src/test/resources/files/test_file_partial.txt");
+        
+        sshClient   = fixture.setupConnectedDefaultClient();
+        sshClient.authPassword("test", "test");
+        xfer = sshClient.newSFTPClient().getFileTransfer();
+    }
+    
+    @After
+    public void cleanup() {
+        if (targetFile.exists()) {
+            targetFile.delete();
+        }
+        
+        if (targetDir.exists()) {
+            targetDir.delete();
+        }
+    }
+    
+    private void performDownload(boolean resume) throws IOException {
+        // Using the resume param this way to call the different entry points into the FileTransfer interface
+        if (resume) {
+            xfer.download(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath(), true);
+        } else {
+            xfer.download(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath());
+        }
+        
+        assertTrue(FileUtil.compareFileContents(sourceFile, targetFile));
+    }
+    
+    private void performUpload(boolean resume) throws IOException {
+        // Using the resume param this way to call the different entry points into the FileTransfer interface
+        if (resume) {
+            xfer.upload(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath(), true);
+        } else {
+            xfer.upload(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath());
+        }
+        assertTrue(FileUtil.compareFileContents(sourceFile, targetFile));
+    }
+    
+    @Test
+    public void testDownload() throws IOException {
+        performDownload(false);
+    }
+    
+    @Test
+    public void testDownloadResumePartial() throws IOException {
+        FileUtil.writeToFile(targetFile, FileUtil.readFromFile(partialFile));
+        assertFalse(FileUtil.compareFileContents(sourceFile, targetFile));
+        performDownload(true);
+    }
+    
+    @Test
+    public void testDownloadResumeNothing() throws IOException {
+        assertFalse(targetFile.exists());
+        performDownload(true);
+    }
+    
+    @Test
+    public void testDownloadResumePreviouslyCompleted() throws IOException {
+        FileUtil.writeToFile(targetFile, FileUtil.readFromFile(sourceFile));
+        assertTrue(FileUtil.compareFileContents(sourceFile, targetFile));
+        performDownload(true);
+    }
+    
+    @Test
+    public void testUpload() throws IOException {
+        performUpload(false);
+    }
+    
+    @Test
+    public void testUploadResumePartial() throws IOException {
+        FileUtil.writeToFile(targetFile, FileUtil.readFromFile(partialFile));
+        assertFalse(FileUtil.compareFileContents(sourceFile, targetFile));
+        performUpload(true);
+    }
+    
+    @Test
+    public void testUploadResumeNothing() throws IOException {
+        assertFalse(targetFile.exists());
+        performUpload(true);
+    }
+    
+    @Test
+    public void testUploadResumePreviouslyCompleted() throws IOException {
+        FileUtil.writeToFile(targetFile, FileUtil.readFromFile(sourceFile));
+        assertTrue(FileUtil.compareFileContents(sourceFile, targetFile));
+        performUpload(true);
+    }
+}

--- a/src/test/java/net/schmizz/sshj/sftp/SFTPFileTransferTest.java
+++ b/src/test/java/net/schmizz/sshj/sftp/SFTPFileTransferTest.java
@@ -30,10 +30,6 @@ import org.junit.rules.TemporaryFolder;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-/**
- *
- * @author Brent Tyler
- */
 public class SFTPFileTransferTest {
     
     public static final String TARGET_FILE_NAME = "target.txt";

--- a/src/test/resources/files/test_file_full.txt
+++ b/src/test/resources/files/test_file_full.txt
@@ -1,0 +1,10 @@
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?

--- a/src/test/resources/files/test_file_partial.txt
+++ b/src/test/resources/files/test_file_partial.txt
@@ -1,0 +1,6 @@
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%^&*(),.;'[]/?
+abcdefghijklmnopqrstuvwxyzABCDEF


### PR DESCRIPTION
Internally SFTPFileTransfer has a few sanity checks to fall back to full replacement even if the resume flag is set.

SCP file transfers have not been changed to support this at this time.