### PR TITLE
Update KeepAlive and RemotePF examples

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -24,7 +24,7 @@
     <groupId>com.hierynomus</groupId>
     <artifactId>sshj-examples</artifactId>
     <packaging>jar</packaging>
-    <version>0.19.1</version>
+    <version>0.33.0</version>
 
     <name>sshj-examples</name>
     <description>Examples for SSHv2 library for Java</description>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.hierynomus</groupId>
             <artifactId>sshj</artifactId>
-            <version>0.31.0</version>
+            <version>0.33.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/src/main/java/net/schmizz/sshj/examples/KeepAlive.java
+++ b/examples/src/main/java/net/schmizz/sshj/examples/KeepAlive.java
@@ -19,8 +19,9 @@ public class KeepAlive {
         final SSHClient ssh = new SSHClient(defaultConfig);
         try {
             ssh.addHostKeyVerifier(new PromiscuousVerifier());
+            // Set interval to enable keep-alive before connecting
+            ssh.getConnection().getKeepAlive().setKeepAliveInterval(5);
             ssh.connect(args[0]);
-            ssh.getConnection().getKeepAlive().setKeepAliveInterval(5); //every 60sec
             ssh.authPassword(args[1], args[2]);
             Session session = ssh.startSession();
             session.allocateDefaultPTY();

--- a/examples/src/main/java/net/schmizz/sshj/examples/RemotePF.java
+++ b/examples/src/main/java/net/schmizz/sshj/examples/RemotePF.java
@@ -19,6 +19,7 @@ public class RemotePF {
         client.loadKnownHosts();
 
         client.connect("localhost");
+        client.getConnection().getKeepAlive().setKeepAliveInterval(5);
         try {
 
             client.authPublickey(System.getProperty("user.name"));
@@ -32,8 +33,6 @@ public class RemotePF {
                     new Forward(8080),
                     // what we do with incoming connections that are forwarded to us
                     new SocketForwardingConnectListener(new InetSocketAddress("google.com", 80)));
-
-            client.getTransport().setHeartbeatInterval(30);
 
             // Something to hang on to so that the forwarding stays
             client.getTransport().join();

--- a/src/main/java/net/schmizz/keepalive/KeepAlive.java
+++ b/src/main/java/net/schmizz/keepalive/KeepAlive.java
@@ -35,14 +35,29 @@ public abstract class KeepAlive extends Thread {
         setDaemon(true);
     }
 
+    /**
+     * KeepAlive enabled based on KeepAlive interval
+     *
+     * @return Enabled when KeepInterval is greater than 0
+     */
     public boolean isEnabled() {
         return keepAliveInterval > 0;
     }
 
+    /**
+     * Get KeepAlive interval in seconds
+     *
+     * @return KeepAlive interval in seconds defaults to 0
+     */
     public synchronized int getKeepAliveInterval() {
         return keepAliveInterval;
     }
 
+    /**
+     * Set KeepAlive interval in seconds
+     *
+     * @param keepAliveInterval KeepAlive interval in seconds
+     */
     public synchronized void setKeepAliveInterval(int keepAliveInterval) {
         this.keepAliveInterval = keepAliveInterval;
     }


### PR DESCRIPTION
As requested in issue #784, this pull request updates the `KeepAlive` example class to set the KeepAlive interval prior to connecting, following the behavior adjustments introduced in SSHJ 0.33.0. The `RemotePF` example follows the same approach for the Heartbeat setting, and removes the call to `Transport.setHeartbeatInterval()`, which is no longer defined.