### PR TITLE
Add Transport.isKeyExchangeRequired() to avoid unnecessary KEXINIT

### DIFF
--- a/src/main/java/com/hierynomus/sshj/common/ThreadNameProvider.java
+++ b/src/main/java/com/hierynomus/sshj/common/ThreadNameProvider.java
@@ -29,7 +29,8 @@ public class ThreadNameProvider {
     public static void setThreadName(final Thread thread, final RemoteAddressProvider remoteAddressProvider) {
         final InetSocketAddress remoteSocketAddress = remoteAddressProvider.getRemoteSocketAddress();
         final String address = remoteSocketAddress == null ? DISCONNECTED : remoteSocketAddress.toString();
-        final String threadName = String.format("sshj-%s-%s", thread.getClass().getSimpleName(), address);
+        final long started = System.currentTimeMillis();
+        final String threadName = String.format("sshj-%s-%s-%d", thread.getClass().getSimpleName(), address, started);
         thread.setName(threadName);
     }
 }

--- a/src/main/java/net/schmizz/sshj/SSHClient.java
+++ b/src/main/java/net/schmizz/sshj/SSHClient.java
@@ -810,7 +810,12 @@ public class SSHClient
             ThreadNameProvider.setThreadName(conn.getKeepAlive(), trans);
             keepAliveThread.start();
         }
-        doKex();
+        if (trans.isKeyExchangeRequired()) {
+            log.debug("Initiating Key Exchange for new connection");
+            doKex();
+        } else {
+            log.debug("Key Exchange already completed for new connection");
+        }
     }
 
     /**

--- a/src/main/java/net/schmizz/sshj/transport/Transport.java
+++ b/src/main/java/net/schmizz/sshj/transport/Transport.java
@@ -71,6 +71,13 @@ public interface Transport
     void doKex()
             throws TransportException;
 
+    /**
+     * Is Key Exchange required based on current transport status
+     *
+     * @return Key Exchange required status
+     */
+    boolean isKeyExchangeRequired();
+
     /** @return the version string used by this client to identify itself to an SSH server, e.g. "SSHJ_3_0" */
     String getClientVersion();
 

--- a/src/main/java/net/schmizz/sshj/transport/TransportImpl.java
+++ b/src/main/java/net/schmizz/sshj/transport/TransportImpl.java
@@ -254,6 +254,16 @@ public final class TransportImpl
         kexer.startKex(true);
     }
 
+    /**
+     * Is Key Exchange required returns true when Key Exchange is not done and when Key Exchange is not ongoing
+     *
+     * @return Key Exchange required status
+     */
+    @Override
+    public boolean isKeyExchangeRequired() {
+        return !kexer.isKexDone() && !kexer.isKexOngoing();
+    }
+
     public boolean isKexDone() {
         return kexer.isKexDone();
     }

--- a/src/test/java/com/hierynomus/sshj/keepalive/KeepAliveThreadTerminationTest.java
+++ b/src/test/java/com/hierynomus/sshj/keepalive/KeepAliveThreadTerminationTest.java
@@ -59,9 +59,10 @@ public class KeepAliveThreadTerminationTest {
         assertEquals(Thread.State.NEW, keepAlive.getState());
 
         fixture.connectClient(sshClient);
-        assertEquals(Thread.State.TIMED_WAITING, keepAlive.getState());
 
         assertThrows(UserAuthException.class, () -> sshClient.authPassword("bad", "credentials"));
+
+        assertEquals(Thread.State.TIMED_WAITING, keepAlive.getState());
 
         fixture.stopClient();
         Thread.sleep(STOP_SLEEP);


### PR DESCRIPTION
This pull request addresses SSH_MSG_UNIMPLEMENTED errors during key exchange described in issue #810.

Changes include adding `isKeyExchangeRequired()` to the `Transport` interface, with an implementation in `TransportImpl` that checks the status of Key Exchange completion and processing.

Checking `KeyExchanger.isKexDone()` indicates that at least one key exchange has not been completed, and checking `KeyExchanger.isKexOngoing()` indicates that a key exchange is not in progress.  Checking `Transport.isKeyExchangeRequired()` in `SSHClient.onConnect()` avoids sending an additional `SSH_MSG_KEXINIT` packet when a key exchange is already in progress or completed.

Additional changes include adding a started timestamp when setting a thread name in `ThreadNameProvider`. The started timestamp makes it easier to distinguished between threads for multiple connections to the same remote host and port.