### PR TITLE
TimeoutException message improved

### DIFF
--- a/src/main/java/net/schmizz/concurrent/Promise.java
+++ b/src/main/java/net/schmizz/concurrent/Promise.java
@@ -136,7 +136,7 @@ public class Promise<V, T extends Throwable> {
             throws T {
         final V value = tryRetrieve(timeout, unit);
         if (value == null)
-            throw chainer.chain(new TimeoutException("Timeout expired"));
+            throw chainer.chain(new TimeoutException("Timeout expired: " + timeout + " " + unit));
         else
             return value;
     }


### PR DESCRIPTION
A minor improvement to include the actual timeout value into the exception message. 
This can get handy in complex scenarios where it is not obvious what timeout is configured for the command that had failed.