### PR TITLE
Set Java 8 as Minimum Required Version and Upgrade Dependencies

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,20 +6,20 @@ name: Build SSHJ
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 
 jobs:
   java12:
-    name: Build with Java 12
+    name: Build with Java 11
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 12
-      uses: actions/setup-java@v1
+    - name: Set up Java 11
+      uses: actions/setup-java@v3
       with:
-        java-version: 12
+        distribution: 'temurin'
+        java-version: 11
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
@@ -29,14 +29,14 @@ jobs:
 
   integration:
     name: Integration test
-    needs: [java12]
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 12
+          distribution: 'temurin'
+          java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/README.adoc
+++ b/README.adoc
@@ -95,7 +95,11 @@ If you need something that is not included, it shouldn't be too hard to add (do 
 http://ssh-comparison.quendi.de/comparison.html[SSH Implementation Comparison]
 
 == Dependencies
-Java 7+. http://www.slf4j.org/download.html[slf4j] is required. http://www.bouncycastle.org/java.html[bouncycastle] is highly recommended and required for using some of the crypto algorithms.
+
+- Java 8 or higher
+- https://www.slf4j.org/[SLF4J 2.0.0]
+- https://www.bouncycastle.org[Bouncy Castle]
+
 
 == Reporting bugs
 Issue tracker: https://github.com/hierynomus/sshj/issues

--- a/build.gradle
+++ b/build.gradle
@@ -35,27 +35,29 @@ project.version = scmVersion.version
 
 configurations.implementation.transitive = false
 
-def bouncycastleVersion = "1.70"
-def sshdVersion = "2.8.0"
+def bouncycastleVersion = "1.75"
+def sshdVersion = "2.10.0"
 
 dependencies {
-  implementation "org.slf4j:slf4j-api:1.7.36"
-  implementation "org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion"
-  implementation "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
+  implementation "org.slf4j:slf4j-api:2.0.7"
+  implementation "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
+  implementation "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
   implementation "com.hierynomus:asn-one:0.6.0"
-
   implementation "net.i2p.crypto:eddsa:0.3.0"
 
-  testImplementation "junit:junit:4.13.2"
-  testImplementation 'org.spockframework:spock-core:1.3-groovy-2.4'
-  testImplementation "org.mockito:mockito-core:4.2.0"
+  testImplementation(platform("org.junit:junit-bom:5.9.3"))
+  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+  testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
+  testImplementation 'org.spockframework:spock-junit4:2.3-groovy-3.0'
+  testImplementation "org.mockito:mockito-core:4.11.0"
   testImplementation "org.apache.sshd:sshd-core:$sshdVersion"
   testImplementation "org.apache.sshd:sshd-sftp:$sshdVersion"
   testImplementation "org.apache.sshd:sshd-scp:$sshdVersion"
-  testImplementation "ch.qos.logback:logback-classic:1.2.11"
-  testImplementation 'org.glassfish.grizzly:grizzly-http-server:2.4.4'
-  testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-  testImplementation 'org.testcontainers:testcontainers:1.16.2'
+  testImplementation "ch.qos.logback:logback-classic:1.3.8"
+  testImplementation 'org.glassfish.grizzly:grizzly-http-server:3.0.1'
+  testImplementation 'org.testcontainers:testcontainers:1.18.3'
 }
 
 license {
@@ -83,7 +85,7 @@ if (JavaVersion.current().isJava8Compatible()) {
 }
 
 compileJava {
-  options.compilerArgs.addAll(['--release', '7'])
+  options.compilerArgs.addAll(['--release', '8'])
 }
 
 task writeSshjVersionProperties {
@@ -118,7 +120,6 @@ jar {
     instruction "Export-Package", "net.schmizz.*;version=\"${project.jar.manifest.version}\""
   }
 }
-
 
 java {
 	withJavadocJar()
@@ -163,14 +164,7 @@ tasks.withType(Test) {
   testLogging {
     exceptionFormat = 'full'
   }
-  include "**/*Test.*"
-  include "**/*Spec.*"
-  if (!project.hasProperty("allTests")) {
-    useJUnit {
-      excludeCategories 'com.hierynomus.sshj.test.SlowTests'
-      excludeCategories 'com.hierynomus.sshj.test.KnownFailingTests'
-    }
-  }
+  useJUnitPlatform()
 
   afterSuite { descriptor, result ->
     if (descriptor.className != null) {

--- a/src/itest/groovy/com/hierynomus/sshj/RsaShaKeySignatureTest.groovy
+++ b/src/itest/groovy/com/hierynomus/sshj/RsaShaKeySignatureTest.groovy
@@ -38,7 +38,7 @@ class RsaShaKeySignatureTest extends Specification {
 
     private static void dockerfileBuilder(DockerfileBuilder it, String hostKey, String pubkeyAcceptedAlgorithms) {
         it.from("archlinux:base")
-        it.run('yes | pacman -Sy core/openssh' +
+        it.run('pacman -Sy --noconfirm core/openssh core/openssl' +
                 ' && (' +
                 '  V=$(echo $(/usr/sbin/sshd -h 2>&1) | grep -o \'OpenSSH_[0-9][0-9]*[.][0-9][0-9]*p[0-9]\');' +
                 '  if [[ "$V" < OpenSSH_8.8p1 ]]; then' +
@@ -61,7 +61,6 @@ class RsaShaKeySignatureTest extends Specification {
                 '-D',
                 '-e',
                 '-f', '/dev/null',
-                '-o', 'LogLevel=DEBUG2',
                 '-o', "HostKey=/etc/ssh/$hostKey",
         ]
         if (pubkeyAcceptedAlgorithms != null) {
@@ -130,7 +129,7 @@ class RsaShaKeySignatureTest extends Specification {
     }
 
     @Unroll
-    def "connect to a server with host key #hostkey that supports only ssh-rsa"() {
+    def "connect to a server with host key #hostKey that supports only ssh-rsa"() {
         given:
         SshdContainer sshd = makeSshdContainer(hostKey, "ssh-rsa,ssh-ed25519")
         sshd.start()


### PR DESCRIPTION
This pull requests changes the Java compiler release version from 7 to 8, making the Java 8 the minimum required version for using SSHJ.

Runtime dependency changes include the following updates:

- Upgraded Bouncy Castle from 1.70 to [1.75](https://bouncycastle.org/releasenotes.html#r1rv75)
- Upgraded SLF4J from 1.7.36 to [2.0.7](https://www.slf4j.org/news.html#2023-03-17%20-ReleaseOfSLF4J2.0.7)

Both of these runtime dependency upgrades require Java 8.

Test dependency changes include the following updates:

- Upgraded Logback from 1.2.11 to [1.3.8](https://logback.qos.ch/news.html#1.3.8)
- Upgraded Apache MINA SSHD from 2.8.0 to 2.10.0
- Upgraded Grizzly HTTP Server from 2.4.4 to 3.0.1
- Upgraded Testcontainers from 1.16.2 to 1.18.3
- Upgraded Spock from 1.3 to 2.0

GitHub Action changes include the following updates:

- Upgraded GitHub Actions setup-java from 1 to 3
- Updated GitHub Actions to use Temurin JDK 11 aligning with the Java build version specified in the project configuration
- Removed the integration test dependency on the build job so that both jobs run in parallel

Test code changes include replacing the Apache HttpClient library references to Java HttpURLConnection, allowing for the test dependency to be removed.

Spock 2.0 uses the Gradle JUnit Platform runner, supporting simplified build configuration.

The RSA algorithm integration tests could fail due to a mismatch between the OpenSSH and OpenSSL versions, requiring an additional package upgrade command.