### PR TITLE
Have newStatefulSFTPClient return StatefulSFTPClient

### DIFF
--- a/src/main/java/net/schmizz/sshj/SSHClient.java
+++ b/src/main/java/net/schmizz/sshj/SSHClient.java
@@ -742,7 +742,7 @@ public class SSHClient
      *
      * @throws IOException if there is an error starting the {@code sftp} subsystem
      */
-    public SFTPClient newStatefulSFTPClient()
+    public StatefulSFTPClient newStatefulSFTPClient()
             throws IOException {
         checkConnected();
         checkAuthenticated();


### PR DESCRIPTION
Avoids casting requirement:

```
StatefulSFTPClient statefulSftpClient = (StatefulSFTPClient) sshClient.newStatefulSFTPClient();
```