### PR TITLE
Implement OpenSSH strict key exchange extension

### DIFF
--- a/src/itest/java/com/hierynomus/sshj/SshdContainer.java
+++ b/src/itest/java/com/hierynomus/sshj/SshdContainer.java
@@ -146,8 +146,9 @@ public class SshdContainer extends GenericContainer<SshdContainer> {
                     .withFileFromString("sshd_config", sshdConfig.build());
         }
 
+        @Override
         public void accept(@NotNull DockerfileBuilder builder) {
-            builder.from("alpine:3.18.3");
+            builder.from("alpine:3.19.0");
             builder.run("apk add --no-cache openssh");
             builder.expose(22);
             builder.copy("entrypoint.sh", "/entrypoint.sh");

--- a/src/itest/java/com/hierynomus/sshj/transport/kex/StrictKeyExchangeTest.java
+++ b/src/itest/java/com/hierynomus/sshj/transport/kex/StrictKeyExchangeTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.transport.kex;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.hierynomus.sshj.SshdContainer;
+import net.schmizz.sshj.SSHClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Testcontainers
+class StrictKeyExchangeTest {
+
+    @Container
+    private static final SshdContainer sshd = new SshdContainer();
+
+    private final List<Logger> watchedLoggers = new ArrayList<>();
+    private final ListAppender<ILoggingEvent> logWatcher = new ListAppender<>();
+
+    @BeforeEach
+    void setUpLogWatcher() {
+        logWatcher.start();
+        setUpLogger("net.schmizz.sshj.transport.Decoder");
+        setUpLogger("net.schmizz.sshj.transport.Encoder");
+        setUpLogger("net.schmizz.sshj.transport.KeyExchanger");
+    }
+
+    @AfterEach
+    void tearDown() {
+        watchedLoggers.forEach(Logger::detachAndStopAllAppenders);
+    }
+
+    private void setUpLogger(String className) {
+        Logger logger = ((Logger) LoggerFactory.getLogger(className));
+        logger.addAppender(logWatcher);
+        watchedLoggers.add(logger);
+    }
+
+    @Test
+    void strictKeyExchange() throws Throwable {
+        try (SSHClient client = sshd.getConnectedClient()) {
+            client.authPublickey("sshj", "src/itest/resources/keyfiles/id_rsa_opensshv1");
+            assertTrue(client.isAuthenticated());
+        }
+        List<String> keyExchangerLogs = getLogs("KeyExchanger");
+        assertThat(keyExchangerLogs).containsSequence(
+            "Initiating key exchange",
+            "Sending SSH_MSG_KEXINIT",
+            "Received SSH_MSG_KEXINIT",
+            "Enabling strict key exchange extension"
+        );
+        List<String> decoderLogs = getLogs("Decoder").stream()
+            .map(log -> log.split(":")[0])
+            .collect(Collectors.toList());
+        assertThat(decoderLogs).containsExactly(
+            "Received packet #0",
+            "Received packet #1",
+            "Received packet #2",
+            "Received packet #0",
+            "Received packet #1",
+            "Received packet #2",
+            "Received packet #3"
+        );
+        List<String> encoderLogs = getLogs("Encoder").stream()
+            .map(log -> log.split(":")[0])
+            .collect(Collectors.toList());
+        assertThat(encoderLogs).containsExactly(
+            "Encoding packet #0",
+            "Encoding packet #1",
+            "Encoding packet #2",
+            "Encoding packet #0",
+            "Encoding packet #1",
+            "Encoding packet #2",
+            "Encoding packet #3"
+        );
+    }
+
+    private List<String> getLogs(String className) {
+        return logWatcher.list.stream()
+            .filter(event -> event.getLoggerName().endsWith(className))
+            .map(ILoggingEvent::getFormattedMessage)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/net/schmizz/sshj/transport/Converter.java
+++ b/src/main/java/net/schmizz/sshj/transport/Converter.java
@@ -51,6 +51,14 @@ abstract class Converter {
         return seq;
     }
 
+    void resetSequenceNumber() {
+        seq = -1;
+    }
+
+    boolean isSequenceNumberAtMax() {
+        return seq == 0xffffffffL;
+    }
+
     void setAlgorithms(Cipher cipher, MAC mac, Compression compression) {
         this.cipher = cipher;
         this.mac = mac;

--- a/src/main/java/net/schmizz/sshj/transport/Proposal.java
+++ b/src/main/java/net/schmizz/sshj/transport/Proposal.java
@@ -37,8 +37,11 @@ class Proposal {
     private final List<String> s2cComp;
     private final SSHPacket packet;
 
-    public Proposal(Config config, List<String> knownHostAlgs) {
+    public Proposal(Config config, List<String> knownHostAlgs, boolean initialKex) {
         kex = Factory.Named.Util.getNames(config.getKeyExchangeFactories());
+        if (initialKex) {
+            kex.add("kex-strict-c-v00@openssh.com");
+        }
         sig = filterKnownHostKeyAlgorithms(Factory.Named.Util.getNames(config.getKeyAlgorithms()), knownHostAlgs);
         c2sCipher = s2cCipher = Factory.Named.Util.getNames(config.getCipherFactories());
         c2sMAC = s2cMAC = Factory.Named.Util.getNames(config.getMACFactories());
@@ -89,6 +92,10 @@ class Proposal {
 
     public List<String> getKeyExchangeAlgorithms() {
         return kex;
+    }
+
+    public boolean isStrictKeyExchangeSupportedByServer() {
+        return kex.contains("kex-strict-s-v00@openssh.com");
     }
 
     public List<String> getHostKeyAlgorithms() {

--- a/src/main/java/net/schmizz/sshj/transport/TransportImpl.java
+++ b/src/main/java/net/schmizz/sshj/transport/TransportImpl.java
@@ -426,7 +426,7 @@ public final class TransportImpl
                     assert m != Message.KEXINIT;
                     kexer.waitForDone();
                 }
-            } else if (encoder.getSequenceNumber() == 0) // We get here every 2**32th packet
+            } else if (encoder.isSequenceNumberAtMax()) // We get here every 2**32th packet
                 kexer.startKex(true);
 
             final long seq = encoder.encode(payload);
@@ -479,9 +479,20 @@ public final class TransportImpl
 
         log.trace("Received packet {}", msg);
 
+        if (kexer.isInitialKex()) {
+            if (decoder.isSequenceNumberAtMax()) {
+                throw new TransportException(DisconnectReason.KEY_EXCHANGE_FAILED,
+                    "Sequence number of decoder is about to wrap during initial key exchange");
+            }
+            if (kexer.isStrictKex() && !isKexerPacket(msg) && msg != Message.DISCONNECT) {
+                throw new TransportException(DisconnectReason.KEY_EXCHANGE_FAILED,
+                    "Unexpected packet type during initial strict key exchange");
+            }
+        }
+
         if (msg.geq(50)) { // not a transport layer packet
             service.handle(msg, buf);
-        } else if (msg.in(20, 21) || msg.in(30, 49)) { // kex packet
+        } else if (isKexerPacket(msg)) {
             kexer.handle(msg, buf);
         } else {
             switch (msg) {
@@ -511,6 +522,10 @@ public final class TransportImpl
                     break;
             }
         }
+    }
+
+    private static boolean isKexerPacket(Message msg) {
+        return msg.in(20, 21) || msg.in(30, 49);
     }
 
     private void gotDebug(SSHPacket buf)

--- a/src/test/java/net/schmizz/sshj/transport/KeyExchangeRepeatTest.java
+++ b/src/test/java/net/schmizz/sshj/transport/KeyExchangeRepeatTest.java
@@ -112,7 +112,7 @@ public class KeyExchangeRepeatTest {
     }
 
     private SSHPacket getKexinitPacket() {
-        SSHPacket kexinitPacket = new Proposal(config, Collections.emptyList()).getPacket();
+        SSHPacket kexinitPacket = new Proposal(config, Collections.emptyList(), false).getPacket();
         kexinitPacket.rpos(kexinitPacket.rpos() + 1);
         return kexinitPacket;
     }


### PR DESCRIPTION
Resolves #916 

The PR implements the algorithm described in section 1.9 of https://github.com/openssh/openssh-portable/blob/master/PROTOCOL and also follows the changes implemented in the commit https://github.com/openssh/openssh-portable/commit/1edb00c58f8a6875fad6a497aa2bacf37f9e6cd5.

All tests are successful. The integration tests work both against the current container and a custom built container with OpenSSH 9.6p1. When run against the latter, the log also show that the resets of sequence numbers are happening, and working correctly as otherwise ChaCha20-Poly1305 should break.

The jsch fork of mwiede also implemented config switches to disable or enforce the strict key exchange extension. But I'm not sure whether it makes sense to maintain such flags long term when OpenSSH itself doesn't have them: https://github.com/mwiede/jsch/pull/461

The Terrapin Scanner referenced in #916 is happy, but I think it only checks whether the additional pseudo-key exchange `kex-strict-c-v00@openssh.com` is being advertised by the client:

```
================================================================================
==================================== Report ====================================
================================================================================

Remote Banner: SSH-2.0-SSHJ_0.18.0

ChaCha20-Poly1305 support:   true
CBC-EtM support:             true

Strict key exchange support: true

==> The scanned peer supports Terrapin mitigations and can establish
    connections that are NOT VULNERABLE to Terrapin. Glad to see this.
    For strict key exchange to take effect, both peers must support it.

Note: This tool is provided as is, with no warranty whatsoever. It determines
      the vulnerability of a peer by checking the supported algorithms and
      support for strict key exchange. It may falsely claim a peer to be
      vulnerable if the vendor supports countermeasures other than strict key
      exchange.

For more details visit our website available at https://terrapin-attack.com
```

