### PR TITLE
connected sockets can be passed to the library

### DIFF
--- a/src/main/java/net/schmizz/sshj/SocketClient.java
+++ b/src/main/java/net/schmizz/sshj/SocketClient.java
@@ -79,10 +79,8 @@ public abstract class SocketClient {
             this.hostname = hostname;
             this.port = port;
             socket = socketFactory.createSocket();
-            if (! socket.isConnected()) {
-                socket.bind(new InetSocketAddress(localAddr, localPort));
-                socket.connect(makeInetSocketAddress(hostname, port), connectTimeout);
-            }
+            socket.bind(new InetSocketAddress(localAddr, localPort));
+            socket.connect(makeInetSocketAddress(hostname, port), connectTimeout);
             onConnect();
         }
     }
@@ -118,10 +116,8 @@ public abstract class SocketClient {
             throws IOException {
         this.port = port;
         socket = socketFactory.createSocket();
-        if (! socket.isConnected()) {
-            socket.bind(new InetSocketAddress(localAddr, localPort));
-            socket.connect(new InetSocketAddress(host, port), connectTimeout);
-        }
+        socket.bind(new InetSocketAddress(localAddr, localPort));
+        socket.connect(new InetSocketAddress(host, port), connectTimeout);
         onConnect();
     }
 

--- a/src/main/java/net/schmizz/sshj/SocketClient.java
+++ b/src/main/java/net/schmizz/sshj/SocketClient.java
@@ -65,7 +65,9 @@ public abstract class SocketClient {
             this.hostname = hostname;
             this.port = port;
             socket = socketFactory.createSocket();
-            socket.connect(makeInetSocketAddress(hostname, port), connectTimeout);
+            if (! socket.isConnected()) {
+                socket.connect(makeInetSocketAddress(hostname, port), connectTimeout);
+            }
             onConnect();
         }
     }
@@ -77,8 +79,10 @@ public abstract class SocketClient {
             this.hostname = hostname;
             this.port = port;
             socket = socketFactory.createSocket();
-            socket.bind(new InetSocketAddress(localAddr, localPort));
-            socket.connect(makeInetSocketAddress(hostname, port), connectTimeout);
+            if (! socket.isConnected()) {
+                socket.bind(new InetSocketAddress(localAddr, localPort));
+                socket.connect(makeInetSocketAddress(hostname, port), connectTimeout);
+            }
             onConnect();
         }
     }
@@ -104,7 +108,9 @@ public abstract class SocketClient {
     public void connect(InetAddress host, int port) throws IOException {
         this.port = port;
         socket = socketFactory.createSocket();
-        socket.connect(new InetSocketAddress(host, port), connectTimeout);
+        if (! socket.isConnected()) {
+            socket.connect(new InetSocketAddress(host, port), connectTimeout);
+        }
         onConnect();
     }
 
@@ -112,8 +118,10 @@ public abstract class SocketClient {
             throws IOException {
         this.port = port;
         socket = socketFactory.createSocket();
-        socket.bind(new InetSocketAddress(localAddr, localPort));
-        socket.connect(new InetSocketAddress(host, port), connectTimeout);
+        if (! socket.isConnected()) {
+            socket.bind(new InetSocketAddress(localAddr, localPort));
+            socket.connect(new InetSocketAddress(host, port), connectTimeout);
+        }
         onConnect();
     }
 

--- a/src/test/java/net/schmizz/sshj/ConnectedSocketTest.java
+++ b/src/test/java/net/schmizz/sshj/ConnectedSocketTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.schmizz.sshj;
+
+import com.hierynomus.sshj.test.SshServerExtension;
+import net.schmizz.sshj.SSHClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import javax.net.SocketFactory;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+
+public class ConnectedSocketTest {
+    @RegisterExtension
+    public SshServerExtension fixture = new SshServerExtension();
+
+    @BeforeEach
+    public void setupClient() throws IOException {
+        SSHClient defaultClient = fixture.setupDefaultClient();
+    }
+
+    @Test
+    public void connectsIfUnconnected() {
+        assertDoesNotThrow(() -> fixture.connectClient(fixture.getClient()));
+    }
+
+    @Test
+    public void handlesConnected() throws IOException {
+        Socket socket = SocketFactory.getDefault().createSocket();
+        SocketFactory factory = new SocketFactory() {
+                @Override
+                public Socket createSocket() {
+                    return socket;
+                }
+                @Override
+                public Socket createSocket(InetAddress host, int port) {
+                    return socket;
+                }
+                @Override
+                public Socket createSocket(InetAddress address, int port,
+                                           InetAddress localAddress, int localPort) {
+                    return socket;
+                }
+                @Override
+                public Socket createSocket(String host, int port) {
+                    return socket;
+                }
+                @Override
+                public Socket createSocket(String host, int port,
+                                           InetAddress localHost, int localPort) {
+                    return socket;
+                }
+            };
+        socket.connect(new InetSocketAddress("localhost", fixture.getServer().getPort()));
+        fixture.getClient().setSocketFactory(factory);
+        assertDoesNotThrow(() -> fixture.connectClient(fixture.getClient()));
+    }
+}

--- a/src/test/java/net/schmizz/sshj/ConnectedSocketTest.java
+++ b/src/test/java/net/schmizz/sshj/ConnectedSocketTest.java
@@ -51,7 +51,7 @@ public class ConnectedSocketTest {
 
     private static void connectViaHostname(SshServerExtension fx) throws IOException {
         SshServer server = fx.getServer();
-        fx.getClient().connect(server.getHost(), server.getPort());
+        fx.getClient().connect("localhost", server.getPort());
     }
 
     private static void connectViaAddr(SshServerExtension fx) throws IOException {


### PR DESCRIPTION
The client should be able to accept sockets that have been already connected to a remote server.