### PR TITLE
Update bouncyCastle to 1.78 to mitigate CVE-2024-29857

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ compileJava {
 
 configurations.implementation.transitive = false
 
-def bouncycastleVersion = "1.75"
+def bouncycastleVersion = "1.78"
 def sshdVersion = "2.10.0"
 
 dependencies {


### PR DESCRIPTION
Bouncy Caste version before 1.78 have 

CVE-2024-29857 - Importing an EC certificate with specially crafted F2m parameters can cause high CPU usage during parameter evaluation.

Is sshj impacted by this vulnerability?