### PR TITLE
Upgrade Bouncy Castle and other dependencies

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,9 +14,9 @@ jobs:
     name: Build with Java 11
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Java 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: 11
@@ -31,9 +31,9 @@ jobs:
     name: Integration test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
     name: Build with Java 12
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up JDK 12
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 12
@@ -30,10 +30,10 @@ jobs:
     needs: [java12]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 12

--- a/build.gradle
+++ b/build.gradle
@@ -41,11 +41,11 @@ compileJava {
 
 configurations.implementation.transitive = false
 
-def bouncycastleVersion = "1.78"
-def sshdVersion = "2.10.0"
+def bouncycastleVersion = "1.78.1"
+def sshdVersion = "2.12.1"
 
 dependencies {
-  implementation "org.slf4j:slf4j-api:2.0.7"
+  implementation "org.slf4j:slf4j-api:2.0.13"
   implementation "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
   implementation "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
   implementation "com.hierynomus:asn-one:0.6.0"
@@ -59,7 +59,6 @@ license {
     java = 'SLASHSTAR_STYLE'
   }
   excludes([
-    '**/sshj/common/Base64.java',
     '**/com/hierynomus/sshj/userauth/keyprovider/bcrypt/*.java',
     '**/files/test_file_*.txt',
   ])
@@ -86,7 +85,7 @@ testing {
     configureEach {
       useJUnitJupiter()
       dependencies {
-        implementation "org.slf4j:slf4j-api:2.0.7"
+        implementation "org.slf4j:slf4j-api:2.0.13"
         implementation 'org.spockframework:spock-core:2.3-groovy-3.0'
         implementation "org.mockito:mockito-core:4.11.0"
         implementation "org.assertj:assertj-core:3.24.2"
@@ -94,7 +93,7 @@ testing {
         implementation "org.apache.sshd:sshd-core:$sshdVersion"
         implementation "org.apache.sshd:sshd-sftp:$sshdVersion"
         implementation "org.apache.sshd:sshd-scp:$sshdVersion"
-        implementation "ch.qos.logback:logback-classic:1.3.8"
+        implementation "ch.qos.logback:logback-classic:1.3.14"
         implementation 'org.glassfish.grizzly:grizzly-http-server:3.0.1'
       }
 
@@ -130,8 +129,8 @@ testing {
     integrationTest(JvmTestSuite) {
       dependencies {
         implementation project()
-        implementation 'org.testcontainers:testcontainers:1.18.3'
-        implementation 'org.testcontainers:junit-jupiter:1.18.3'
+        implementation 'org.testcontainers:testcontainers:1.19.8'
+        implementation 'org.testcontainers:junit-jupiter:1.19.8'
       }
 
       sources {


### PR DESCRIPTION
This pull request upgrades the following dependencies:

- Upgraded Bouncy Castle from 1.78 to [1.78.1](https://www.bouncycastle.org/releasenotes.html#r1rv78d1)
- Upgraded SLF4J from 2.0.7 to [2.0.13](https://www.slf4j.org/news.html#2.0.13)
- Upgraded SSHD from 2.10.0 to [2.12.1](https://mina.apache.org/sshd-project/download_2.12.1.html)
- Upgraded Logback from 1.3.8 to [1.3.14](https://logback.qos.ch/news.html#1.3.14)
- Upgraded Testcontainers from 1.18.3 to [1.19.8](https://github.com/testcontainers/testcontainers-java/releases/tag/1.19.8)
- Upgraded setup-java action to version [4](https://github.com/actions/setup-java/releases/tag/v4.2.1)
- Upgraded checkout action to version [4](https://github.com/actions/checkout/releases/tag/v4.1.5)