### PR TITLE
Improve Curve25519 Public Key Handling

### DIFF
--- a/src/test/java/net/schmizz/sshj/transport/kex/Curve25519DHTest.java
+++ b/src/test/java/net/schmizz/sshj/transport/kex/Curve25519DHTest.java
@@ -15,16 +15,23 @@
  */
 package net.schmizz.sshj.transport.kex;
 
+import net.schmizz.sshj.common.SecurityUtils;
 import net.schmizz.sshj.transport.random.JCERandom;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
+import java.security.KeyPairGenerator;
+import java.security.Provider;
+import java.security.Security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class Curve25519DHTest {
+
+    private static final String ALGORITHM_FILTER = "KeyPairGenerator.X25519";
 
     private static final int KEY_LENGTH = 32;
 
@@ -35,8 +42,16 @@ public class Curve25519DHTest {
         1, 2, 3, 4, 5, 6, 7, 8
     };
 
+    @BeforeEach
+    public void clearSecurityProvider() {
+        SecurityUtils.setSecurityProvider(null);
+    }
+
     @Test
     public void testInitPublicKeyLength() throws GeneralSecurityException {
+        final boolean bouncyCastleRegistrationRequired = isAlgorithmUnsupported();
+        SecurityUtils.setRegisterBouncyCastle(bouncyCastleRegistrationRequired);
+
         final Curve25519DH dh = new Curve25519DH();
         dh.init(null, new JCERandom.Factory());
 
@@ -48,6 +63,8 @@ public class Curve25519DHTest {
 
     @Test
     public void testInitComputeSharedSecretKey() throws GeneralSecurityException {
+        SecurityUtils.setRegisterBouncyCastle(true);
+
         final Curve25519DH dh = new Curve25519DH();
         dh.init(null, new JCERandom.Factory());
 
@@ -56,5 +73,10 @@ public class Curve25519DHTest {
 
         assertNotNull(sharedSecretKey);
         assertEquals(BigInteger.ONE.signum(), sharedSecretKey.signum());
+    }
+
+    private boolean isAlgorithmUnsupported() {
+        final Provider[] providers = Security.getProviders(ALGORITHM_FILTER);
+        return providers == null || providers.length == 0;
     }
 }


### PR DESCRIPTION
This pull request improves public key handling for Curve25519 key agreement when running on Java 11 without the Bouncy Castle Security Provider registered.

The Bouncy Castle Security Provider supports `X25519` and returns the encoded public key with a length of `44`. Java 17 and 21 also return encoded public keys of the same length. The Java 11 implementation of `X25519` returns the encoded public key with a length of `46`, where the DER header contains 14 bytes instead of 12. This results in exceptions at runtime as described in #957.

Adjusting the behavior of `Curve25519DH` to calculate the DER header and algorithm identifier based on the length of the encoded public key provides a solution that works across Java versions, with or without the Bouncy Castle Provider.

Changes include unit test improvements to exercise the `Curve25519DH` methods with and without the Bouncy Castle Provider.