### PR TITLE
Check error stream is not null before notifying error

### DIFF
--- a/src/main/java/net/schmizz/sshj/connection/channel/direct/SessionChannel.java
+++ b/src/main/java/net/schmizz/sshj/connection/channel/direct/SessionChannel.java
@@ -225,7 +225,9 @@ public class SessionChannel
 
     @Override
     public void notifyError(SSHException error) {
-        err.notifyError(error);
+        if (err != null) {
+            err.notifyError(error);
+        }
         super.notifyError(error);
     }
 


### PR DESCRIPTION
Fixes #955 

We are getting this exception frequently, when the network to the server is poor (ie., there are a lot of dropped packets at the server, for example):
```
java.lang.NullPointerException: null
	at net.schmizz.sshj.connection.channel.direct.SessionChannel.notifyError(SessionChannel.java:228) ~[sshj-0.31.0.jar:0.31.0]
	at net.schmizz.sshj.common.ErrorNotifiable$Util.alertAll(ErrorNotifiable.java:35) ~[sshj-0.31.0.jar:0.31.0]
	at net.schmizz.sshj.connection.ConnectionImpl.notifyError(ConnectionImpl.java:261) ~[sshj-0.31.0.jar:0.31.0]
	at net.schmizz.sshj.transport.TransportImpl.die(TransportImpl.java:620) ~[sshj-0.31.0.jar:0.31.0]
	at net.schmizz.sshj.transport.Reader.run(Reader.java:66) ~[sshj-0.31.0.jar:0.31.0]
```

I can't really see how the ```err``` variable in ```SessionChannel``` can be null, but apparently sometimes it is.
This kind of check is already done in ```AbstractChannel.notifyError``` (although only for the ```out``` stream), so I'm doing it in ```SessionChannel``` as well.