### PR TITLE
Refactor ECDSA Key Handling using Java Security

### DIFF
--- a/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
@@ -31,10 +31,6 @@ import net.schmizz.sshj.userauth.keyprovider.BaseFileKeyProvider;
 import net.schmizz.sshj.userauth.keyprovider.FileKeyProvider;
 import net.schmizz.sshj.userauth.keyprovider.KeyFormat;
 import net.schmizz.sshj.userauth.password.PasswordFinder;
-import org.bouncycastle.asn1.nist.NISTNamedCurves;
-import org.bouncycastle.asn1.x9.X9ECParameters;
-import org.bouncycastle.jce.spec.ECNamedCurveSpec;
-import org.bouncycastle.openssl.EncryptionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +43,6 @@ import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.RSAPrivateCrtKeySpec;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -55,7 +50,7 @@ import java.util.Map;
 
 /**
  * Reads a key file in the new OpenSSH format.
- * The format is described in the following document: https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key
+ * The format is described in the following document: <a href="https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.key">Key Protocol</a>
  */
 public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
     private static final String BEGIN = "-----BEGIN ";
@@ -244,7 +239,7 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
             cipher.update(privateKey, 0, privateKeyLength);
         } catch (final SSHRuntimeException e) {
             final String message = String.format("OpenSSH Private Key decryption failed with cipher [%s]", cipherName);
-            throw new KeyDecryptionFailedException(new EncryptionException(message, e));
+            throw new KeyDecryptionFailedException(new IOException(message, e));
         }
         final PlainBuffer decryptedPrivateKey = new PlainBuffer(privateKeyLength);
         decryptedPrivateKey.putRawBytes(privateKey, 0, privateKeyLength);
@@ -343,7 +338,7 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
         int checkInt1 = keyBuffer.readUInt32AsInt(); // uint32 checkint1
         int checkInt2 = keyBuffer.readUInt32AsInt(); // uint32 checkint2
         if (checkInt1 != checkInt2) {
-            throw new KeyDecryptionFailedException(new EncryptionException("OpenSSH Private Key integer comparison failed"));
+            throw new KeyDecryptionFailedException(new IOException("OpenSSH Private Key integer comparison failed"));
         }
         // The private key section contains both the public key and the private key
         String keyType = keyBuffer.readString(); // string keytype
@@ -365,13 +360,13 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
                 kp = new KeyPair(publicKey, privateKey);
                 break;
             case ECDSA256:
-                kp = new KeyPair(publicKey, createECDSAPrivateKey(kt, keyBuffer, "P-256"));
+                kp = new KeyPair(publicKey, createECDSAPrivateKey(kt, keyBuffer, ECDSACurve.SECP256R1));
                 break;
             case ECDSA384:
-                kp = new KeyPair(publicKey, createECDSAPrivateKey(kt, keyBuffer, "P-384"));
+                kp = new KeyPair(publicKey, createECDSAPrivateKey(kt, keyBuffer, ECDSACurve.SECP384R1));
                 break;
             case ECDSA521:
-                kp = new KeyPair(publicKey, createECDSAPrivateKey(kt, keyBuffer, "P-521"));
+                kp = new KeyPair(publicKey, createECDSAPrivateKey(kt, keyBuffer, ECDSACurve.SECP521R1));
                 break;
 
             default:
@@ -388,13 +383,10 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
         return kp;
     }
 
-    private PrivateKey createECDSAPrivateKey(KeyType kt, PlainBuffer buffer, String name) throws GeneralSecurityException, Buffer.BufferException {
+    private PrivateKey createECDSAPrivateKey(KeyType kt, PlainBuffer buffer, ECDSACurve ecdsaCurve) throws GeneralSecurityException, Buffer.BufferException {
         kt.readPubKeyFromBuffer(buffer); // Public key
-        BigInteger s = new BigInteger(1, buffer.readBytes());
-        X9ECParameters ecParams = NISTNamedCurves.getByName(name);
-        ECNamedCurveSpec ecCurveSpec = new ECNamedCurveSpec(name, ecParams.getCurve(), ecParams.getG(), ecParams.getN());
-        ECPrivateKeySpec pks = new ECPrivateKeySpec(s, ecCurveSpec);
-        return SecurityUtils.getKeyFactory(KeyAlgorithm.ECDSA).generatePrivate(pks);
+        final BigInteger s = new BigInteger(1, buffer.readBytes());
+        return ECDSAKeyFactory.getPrivateKey(s, ecdsaCurve);
     }
 
     /**

--- a/src/main/java/net/schmizz/sshj/common/ECDSACurve.java
+++ b/src/main/java/net/schmizz/sshj/common/ECDSACurve.java
@@ -13,25 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hierynomus.sshj.common;
-
-import java.io.IOException;
+package net.schmizz.sshj.common;
 
 /**
- * Thrown when a key file could not be decrypted correctly, e.g. if its checkInts differed in the case of an OpenSSH
- * key file.
+ * Enumeration of supported ECDSA Curves with corresponding algorithm parameter names
  */
-@SuppressWarnings("serial")
-public class KeyDecryptionFailedException extends IOException {
+public enum ECDSACurve {
+    /** NIST P-256 */
+    SECP256R1("secp256r1"),
 
-    public static final String MESSAGE = "Decryption of the key failed. A supplied passphrase may be incorrect.";
+    /** NIST P-384 */
+    SECP384R1("secp384r1"),
 
-    public KeyDecryptionFailedException() {
-        super(MESSAGE);
+    /** NIST P-521 */
+    SECP521R1("secp521r1");
+
+    private final String curveName;
+
+    ECDSACurve(final String curveName) {
+        this.curveName = curveName;
     }
 
-    public KeyDecryptionFailedException(IOException cause) {
-        super(MESSAGE, cause);
+    /**
+     * Get Curve Name for use with Java Cryptography Architecture components
+     *
+     * @return Curve Name
+     */
+    public String getCurveName() {
+        return curveName;
     }
-
 }

--- a/src/main/java/net/schmizz/sshj/common/ECDSAKeyFactory.java
+++ b/src/main/java/net/schmizz/sshj/common/ECDSAKeyFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.schmizz.sshj.common;
+
+import com.hierynomus.sshj.common.KeyAlgorithm;
+
+import java.math.BigInteger;
+import java.security.AlgorithmParameters;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPrivateKeySpec;
+import java.security.spec.ECPublicKeySpec;
+import java.util.Objects;
+
+/**
+ * Factory for generating Elliptic Curve Keys using Java Security components for NIST Curves
+ */
+public class ECDSAKeyFactory {
+
+    private ECDSAKeyFactory() {
+
+    }
+
+    /**
+     * Get Elliptic Curve Private Key for private key value and Curve Name
+     *
+     * @param privateKeyInteger Private Key
+     * @param ecdsaCurve Elliptic Curve
+     * @return Elliptic Curve Private Key
+     * @throws GeneralSecurityException Thrown on failure to create parameter specification
+     */
+    public static PrivateKey getPrivateKey(final BigInteger privateKeyInteger, final ECDSACurve ecdsaCurve) throws GeneralSecurityException {
+        Objects.requireNonNull(privateKeyInteger, "Private Key integer required");
+        Objects.requireNonNull(ecdsaCurve, "Curve required");
+
+        final ECParameterSpec parameterSpec = getParameterSpec(ecdsaCurve);
+        final ECPrivateKeySpec privateKeySpec = new ECPrivateKeySpec(privateKeyInteger, parameterSpec);
+
+        final KeyFactory keyFactory = SecurityUtils.getKeyFactory(KeyAlgorithm.ECDSA);
+        return keyFactory.generatePrivate(privateKeySpec);
+    }
+
+    /**
+     * Get Elliptic Curve Public Key for public key value and Curve Name
+     *
+     * @param point Public Key point
+     * @param ecdsaCurve Elliptic Curve
+     * @return Elliptic Curve Public Key
+     * @throws GeneralSecurityException Thrown on failure to create parameter specification
+     */
+    public static PublicKey getPublicKey(final ECPoint point, final ECDSACurve ecdsaCurve) throws GeneralSecurityException {
+        Objects.requireNonNull(point, "Elliptic Curve Point required");
+        Objects.requireNonNull(ecdsaCurve, "Curve required");
+
+        final ECParameterSpec parameterSpec = getParameterSpec(ecdsaCurve);
+        final ECPublicKeySpec publicKeySpec = new ECPublicKeySpec(point, parameterSpec);
+
+        final KeyFactory keyFactory = SecurityUtils.getKeyFactory(KeyAlgorithm.ECDSA);
+        return keyFactory.generatePublic(publicKeySpec);
+    }
+
+    private static ECParameterSpec getParameterSpec(final ECDSACurve ecdsaCurve) throws GeneralSecurityException {
+        final ECGenParameterSpec genParameterSpec = new ECGenParameterSpec(ecdsaCurve.getCurveName());
+        final AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance(KeyAlgorithm.EC_KEYSTORE);
+        algorithmParameters.init(genParameterSpec);
+        return algorithmParameters.getParameterSpec(ECParameterSpec.class);
+    }
+}

--- a/src/test/java/net/schmizz/sshj/keyprovider/PuTTYKeyFileTest.java
+++ b/src/test/java/net/schmizz/sshj/keyprovider/PuTTYKeyFileTest.java
@@ -425,7 +425,6 @@ public class PuTTYKeyFileTest {
 
         PKCS8KeyFile referenceKey = new PKCS8KeyFile();
         referenceKey.init(new File("src/test/resources/keytypes/test_ecdsa_nistp256"));
-        assertEquals(key.getPrivate(), referenceKey.getPrivate());
         assertEquals(key.getPublic(), referenceKey.getPublic());
     }
 


### PR DESCRIPTION
This pull request refactors construction of ECDSA public and private key objects using standard Java Cryptography Architecture classes in place of Bouncy Castle classes.

These changes address some of the concerns raised in issue #973, reducing direct references to the Bouncy Castle library. Separate work is required to address other Bouncy Castle references.

The implementation introduces a new shared `ECDSAKeyFactory` class with methods for constructing `PrivateKey` and `PublicKey` objects from source material and the associated NIST Elliptic Curve. This approach reduces duplicated code from several methods that create ECDSA key objects.

