### PR TITLE
Remove Bouncy Castle usage from Tests

### DIFF
--- a/src/itest/java/com/hierynomus/sshj/sftp/FileWriteTest.java
+++ b/src/itest/java/com/hierynomus/sshj/sftp/FileWriteTest.java
@@ -21,7 +21,6 @@ import java.util.EnumSet;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
 
 import com.hierynomus.sshj.SshdContainer;
 
@@ -31,11 +30,12 @@ import net.schmizz.sshj.sftp.RemoteFile;
 import net.schmizz.sshj.sftp.SFTPClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 @Testcontainers
 public class FileWriteTest {
     @Container
-    private static SshdContainer sshd = new SshdContainer();
+    private static final SshdContainer sshd = new SshdContainer();
 
     @Test
     public void shouldAppendToFile_GH390() throws Throwable {
@@ -63,8 +63,14 @@ public class FileWriteTest {
                 try (RemoteFile read = sftp.open(file, EnumSet.of(OpenMode.READ))) {
                     byte[] readBytes = new byte[initialText.length + appendText.length];
                     read.read(0, readBytes, 0, readBytes.length);
-                    assertThat(Arrays.copyOfRange(readBytes, 0, initialText.length)).isEqualTo(initialText);
-                    assertThat(Arrays.copyOfRange(readBytes, initialText.length, initialText.length + appendText.length)).isEqualTo(appendText);
+
+                    final byte[] expectedInitialText = new byte[initialText.length];
+                    System.arraycopy(readBytes, 0, expectedInitialText, 0, expectedInitialText.length);
+                    assertArrayEquals(expectedInitialText, initialText);
+
+                    final byte[] expectedAppendText = new byte[appendText.length];
+                    System.arraycopy(readBytes, initialText.length, expectedAppendText, 0, expectedAppendText.length);
+                    assertArrayEquals(expectedAppendText, appendText);
                 }
             }
 

--- a/src/test/java/com/hierynomus/sshj/transport/GcmCipherDecryptSshPacketTest.java
+++ b/src/test/java/com/hierynomus/sshj/transport/GcmCipherDecryptSshPacketTest.java
@@ -19,13 +19,10 @@ import com.hierynomus.sshj.transport.cipher.GcmCiphers;
 import net.schmizz.sshj.common.IOUtils;
 import net.schmizz.sshj.common.SSHPacket;
 import net.schmizz.sshj.transport.cipher.Cipher;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.security.Security;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
@@ -40,11 +37,6 @@ public class GcmCipherDecryptSshPacketTest {
 
     public static Stream<Arguments> sets() {
         return Stream.of(Arguments.of("mina-sshd", 3), Arguments.of("openssh", 4));
-    }
-
-    @BeforeAll
-    public static void setupBeforeClass() {
-        Security.addProvider(new BouncyCastleProvider());
     }
 
     @ParameterizedTest

--- a/src/test/java/com/hierynomus/sshj/transport/verification/OpenSSHKnownHostsTest.java
+++ b/src/test/java/com/hierynomus/sshj/transport/verification/OpenSSHKnownHostsTest.java
@@ -16,10 +16,8 @@
 package com.hierynomus.sshj.transport.verification;
 
 import net.schmizz.sshj.common.Buffer;
-import net.schmizz.sshj.common.SecurityUtils;
 import net.schmizz.sshj.transport.verification.OpenSSHKnownHosts;
 import net.schmizz.sshj.util.KeyUtil;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -40,11 +38,6 @@ import static org.junit.jupiter.api.Assertions.*;
 public class OpenSSHKnownHostsTest {
     @TempDir
     public File tempDir;
-
-    @BeforeAll
-    public static void setup() {
-        SecurityUtils.registerSecurityProvider("org.bouncycastle.jce.provider.BouncyCastleProvider");
-    }
 
     @Test
     public void shouldParseAndVerifyHashedHostEntry() throws Exception {

--- a/src/test/java/net/schmizz/sshj/transport/DecoderDecryptGcmCipherSshPacketTest.java
+++ b/src/test/java/net/schmizz/sshj/transport/DecoderDecryptGcmCipherSshPacketTest.java
@@ -22,12 +22,10 @@ import net.schmizz.sshj.common.LoggerFactory;
 import net.schmizz.sshj.common.SSHException;
 import net.schmizz.sshj.common.SSHPacket;
 import net.schmizz.sshj.transport.cipher.Cipher;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.security.SecureRandom;
-import java.security.Security;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -49,7 +47,6 @@ public class DecoderDecryptGcmCipherSshPacketTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        Security.addProvider(new BouncyCastleProvider());
         ClassLoader classLoader = DecoderDecryptGcmCipherSshPacketTest.class.getClassLoader();
         iv = IOUtils.readFully(classLoader.getResourceAsStream("ssh-packets/gcm/mina-sshd/s2c.iv.bin" )).toByteArray();
         key = IOUtils.readFully(classLoader.getResourceAsStream("ssh-packets/gcm/mina-sshd/s2c.key.bin" )).toByteArray();

--- a/src/test/java/net/schmizz/sshj/transport/mac/BaseMacTest.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/BaseMacTest.java
@@ -17,10 +17,11 @@ package net.schmizz.sshj.transport.mac;
 
 import com.hierynomus.sshj.transport.mac.Macs;
 import net.schmizz.sshj.common.SSHRuntimeException;
-import org.bouncycastle.util.encoders.Hex;
+import org.apache.sshd.common.util.buffer.BufferUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,9 +29,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class BaseMacTest {
-    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final Charset CHARSET = StandardCharsets.US_ASCII;
     private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
-    private static final String EXPECTED_HMAC = "24ddeed57ad91465c5b59dce74ef73778bfb0cb9";
+    private static final String EXPECTED_HMAC = "24 dd ee d5 7a d9 14 65 c5 b5 9d ce 74 ef 73 77 8b fb 0c b9";
     private static final String KEY = "et1Quo5ooCie6theel8i";
 
     @Test
@@ -38,7 +39,7 @@ public class BaseMacTest {
         BaseMAC hmac = Macs.HMACSHA1().create();
         hmac.init((KEY + "foo").getBytes(CHARSET));
         hmac.update(PLAIN_TEXT);
-        assertThat(Hex.toHexString(hmac.doFinal()),  is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal()),  is(EXPECTED_HMAC));
     }
 
     @Test
@@ -54,7 +55,7 @@ public class BaseMacTest {
     public void testUpdateWithDoFinal() {
         BaseMAC hmac = initHmac();
         hmac.update(PLAIN_TEXT);
-        assertThat(Hex.toHexString(hmac.doFinal()),  is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal()),  is(EXPECTED_HMAC));
     }
 
     @Test
@@ -67,13 +68,13 @@ public class BaseMacTest {
 
         // update with the range from the second to penultimate byte
         hmac.update(plainText, 1, PLAIN_TEXT.length);
-        assertThat(Hex.toHexString(hmac.doFinal()),  is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal()),  is(EXPECTED_HMAC));
     }
 
     @Test
     public void testDoFinalWithInput() {
         BaseMAC hmac = initHmac();
-        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
     }
 
     @Test
@@ -82,7 +83,7 @@ public class BaseMacTest {
         byte[] resultBuf = new byte[20];
         hmac.update(PLAIN_TEXT);
         hmac.doFinal(resultBuf, 0);
-        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(resultBuf), is(EXPECTED_HMAC));
     }
 
     private BaseMAC initHmac() {

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACMD596Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACMD596Test.java
@@ -16,30 +16,31 @@
 package net.schmizz.sshj.transport.mac;
 
 import com.hierynomus.sshj.transport.mac.Macs;
-import org.bouncycastle.util.encoders.Hex;
+import org.apache.sshd.common.util.buffer.BufferUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class HMACMD596Test {
-    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final Charset CHARSET = StandardCharsets.US_ASCII;
     private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
-    private static final String EXPECTED_HMAC = "dff33c507463f9cf088a5ce8";
+    private static final String EXPECTED_HMAC = "df f3 3c 50 74 63 f9 cf 08 8a 5c e8";
 
     @Test
     public void testUpdateWithDoFinal() {
         BaseMAC hmac = initHmac();
         hmac.update(PLAIN_TEXT);
-        assertThat(Hex.toHexString(hmac.doFinal()), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal()), is(EXPECTED_HMAC));
     }
 
     @Test
     public void testDoFinalWithInput() {
         BaseMAC hmac = initHmac();
-        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)),
+        assertThat(BufferUtils.toHex(hmac.doFinal(PLAIN_TEXT)),
                 is(EXPECTED_HMAC));
     }
 
@@ -49,7 +50,7 @@ public class HMACMD596Test {
         byte[] resultBuf = new byte[12];
         hmac.update(PLAIN_TEXT);
         hmac.doFinal(resultBuf, 0);
-        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(resultBuf), is(EXPECTED_HMAC));
     }
 
     private BaseMAC initHmac() {

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACMD5Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACMD5Test.java
@@ -16,30 +16,31 @@
 package net.schmizz.sshj.transport.mac;
 
 import com.hierynomus.sshj.transport.mac.Macs;
-import org.bouncycastle.util.encoders.Hex;
+import org.apache.sshd.common.util.buffer.BufferUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class HMACMD5Test {
-    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final Charset CHARSET = StandardCharsets.US_ASCII;
     private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
-    private static final String EXPECTED_HMAC = "dff33c507463f9cf088a5ce8d969c386";
+    private static final String EXPECTED_HMAC = "df f3 3c 50 74 63 f9 cf 08 8a 5c e8 d9 69 c3 86";
 
     @Test
     public void testUpdateWithDoFinal() {
         BaseMAC hmac = initHmac();
         hmac.update(PLAIN_TEXT);
-        assertThat(Hex.toHexString(hmac.doFinal()), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal()), is(EXPECTED_HMAC));
     }
 
     @Test
     public void testDoFinalWithInput() {
         BaseMAC hmac = initHmac();
-        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
     }
 
     @Test
@@ -48,7 +49,7 @@ public class HMACMD5Test {
         byte[] resultBuf = new byte[16];
         hmac.update(PLAIN_TEXT);
         hmac.doFinal(resultBuf, 0);
-        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(resultBuf), is(EXPECTED_HMAC));
     }
 
     private BaseMAC initHmac() {

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA196Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA196Test.java
@@ -16,30 +16,31 @@
 package net.schmizz.sshj.transport.mac;
 
 import com.hierynomus.sshj.transport.mac.Macs;
-import org.bouncycastle.util.encoders.Hex;
+import org.apache.sshd.common.util.buffer.BufferUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class HMACSHA196Test {
-    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final Charset CHARSET = StandardCharsets.US_ASCII;
     private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
-    private static final String EXPECTED_HMAC = "24ddeed57ad91465c5b59dce";
+    private static final String EXPECTED_HMAC = "24 dd ee d5 7a d9 14 65 c5 b5 9d ce";
 
     @Test
     public void testUpdateWithDoFinal() {
         BaseMAC hmac = initHmac();
         hmac.update(PLAIN_TEXT);
-        assertThat(Hex.toHexString(hmac.doFinal()), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal()), is(EXPECTED_HMAC));
     }
 
     @Test
     public void testDoFinalWithInput() {
         BaseMAC hmac = initHmac();
-        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
     }
 
     @Test
@@ -48,7 +49,7 @@ public class HMACSHA196Test {
         byte[] resultBuf = new byte[12];
         hmac.update(PLAIN_TEXT);
         hmac.doFinal(resultBuf, 0);
-        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(resultBuf), is(EXPECTED_HMAC));
     }
 
     private BaseMAC initHmac() {

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA1Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA1Test.java
@@ -16,30 +16,31 @@
 package net.schmizz.sshj.transport.mac;
 
 import com.hierynomus.sshj.transport.mac.Macs;
-import org.bouncycastle.util.encoders.Hex;
+import org.apache.sshd.common.util.buffer.BufferUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class HMACSHA1Test {
-    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final Charset CHARSET = StandardCharsets.US_ASCII;
     private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
-    private static final String EXPECTED_HMAC = "24ddeed57ad91465c5b59dce74ef73778bfb0cb9";
+    private static final String EXPECTED_HMAC = "24 dd ee d5 7a d9 14 65 c5 b5 9d ce 74 ef 73 77 8b fb 0c b9";
 
     @Test
     public void testUpdateWithDoFinal() {
         BaseMAC hmac = initHmac();
         hmac.update(PLAIN_TEXT);
-        assertThat(Hex.toHexString(hmac.doFinal()),  is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal()),  is(EXPECTED_HMAC));
     }
 
     @Test
     public void testDoFinalWithInput() {
         BaseMAC hmac = initHmac();
-        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
     }
 
     @Test
@@ -48,7 +49,7 @@ public class HMACSHA1Test {
         byte[] resultBuf = new byte[20];
         hmac.update(PLAIN_TEXT);
         hmac.doFinal(resultBuf, 0);
-        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(resultBuf), is(EXPECTED_HMAC));
     }
 
     private BaseMAC initHmac() {

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA2256Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA2256Test.java
@@ -16,30 +16,31 @@
 package net.schmizz.sshj.transport.mac;
 
 import com.hierynomus.sshj.transport.mac.Macs;
-import org.bouncycastle.util.encoders.Hex;
+import org.apache.sshd.common.util.buffer.BufferUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class HMACSHA2256Test {
-    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final Charset CHARSET = StandardCharsets.US_ASCII;
     private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
-    private static final String EXPECTED_HMAC = "eb2207b2df36c7485f46d1be30418bc44e8134b4fdaabbe16d71f56ab24fce88";
+    private static final String EXPECTED_HMAC = "eb 22 07 b2 df 36 c7 48 5f 46 d1 be 30 41 8b c4 4e 81 34 b4 fd aa bb e1 6d 71 f5 6a b2 4f ce 88";
 
     @Test
     public void testUpdateWithDoFinal() {
         BaseMAC hmac = initHmac();
         hmac.update(PLAIN_TEXT);
-        assertThat(Hex.toHexString(hmac.doFinal()), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal()), is(EXPECTED_HMAC));
     }
 
     @Test
     public void testDoFinalWithInput() {
         BaseMAC hmac = initHmac();
-        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
     }
 
     @Test
@@ -48,7 +49,7 @@ public class HMACSHA2256Test {
         byte[] resultBuf = new byte[32];
         hmac.update(PLAIN_TEXT);
         hmac.doFinal(resultBuf, 0);
-        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(resultBuf), is(EXPECTED_HMAC));
     }
 
     private BaseMAC initHmac() {

--- a/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA2512Test.java
+++ b/src/test/java/net/schmizz/sshj/transport/mac/HMACSHA2512Test.java
@@ -16,30 +16,31 @@
 package net.schmizz.sshj.transport.mac;
 
 import com.hierynomus.sshj.transport.mac.Macs;
-import org.bouncycastle.util.encoders.Hex;
+import org.apache.sshd.common.util.buffer.BufferUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class HMACSHA2512Test {
-    private static final Charset CHARSET = Charset.forName("US-ASCII");
+    private static final Charset CHARSET = StandardCharsets.US_ASCII;
     private static final byte[] PLAIN_TEXT = "Hello World".getBytes(CHARSET);
-    private static final String EXPECTED_HMAC = "28929cffc903039ef18cbc9cea6fd5f1420763af297a470d731236ed1f5a4c61d64dfccf6529265205bec932f2f7850c8ae4de1dc1a5259dc5b1fd85d8e62c04";
+    private static final String EXPECTED_HMAC = "28 92 9c ff c9 03 03 9e f1 8c bc 9c ea 6f d5 f1 42 07 63 af 29 7a 47 0d 73 12 36 ed 1f 5a 4c 61 d6 4d fc cf 65 29 26 52 05 be c9 32 f2 f7 85 0c 8a e4 de 1d c1 a5 25 9d c5 b1 fd 85 d8 e6 2c 04";
 
     @Test
     public void testUpdateWithDoFinal() {
         BaseMAC hmac = initHmac();
         hmac.update(PLAIN_TEXT);
-        assertThat(Hex.toHexString(hmac.doFinal()), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal()), is(EXPECTED_HMAC));
     }
 
     @Test
     public void testDoFinalWithInput() {
         BaseMAC hmac = initHmac();
-        assertThat(Hex.toHexString(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(hmac.doFinal(PLAIN_TEXT)), is(EXPECTED_HMAC));
     }
 
     @Test
@@ -48,7 +49,7 @@ public class HMACSHA2512Test {
         byte[] resultBuf = new byte[64];
         hmac.update(PLAIN_TEXT);
         hmac.doFinal(resultBuf, 0);
-        assertThat(Hex.toHexString(resultBuf), is(EXPECTED_HMAC));
+        assertThat(BufferUtils.toHex(resultBuf), is(EXPECTED_HMAC));
     }
 
     private BaseMAC initHmac() {


### PR DESCRIPTION
This pull request removes Bouncy Castle class references from tests.

Some changes involve removing unnecessary registration of the `BouncyCastleProvider` in several tests, and replacing the Bouncy Castle `Hex.toHexString()` with Apache SSHD `BufferUtils.toHex()` in other test cases.

This relates to a broader effort described in issue #973 for reducing usage of Bouncy Castle in general.