### PR TITLE
Set Bouncy Castle as optional feature in Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,19 @@ configurations.implementation.transitive = false
 def bouncycastleVersion = "1.80"
 def sshdVersion = "2.15.0"
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+    registerFeature('bouncyCastle') {
+        usingSourceSet(sourceSets.main)
+    }
+}
+
 dependencies {
   implementation "org.slf4j:slf4j-api:2.0.17"
-  implementation "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
-  implementation "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
   implementation "com.hierynomus:asn-one:0.6.0"
+  bouncyCastleImplementation "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
+  bouncyCastleImplementation "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
 }
 
 license {
@@ -66,11 +74,6 @@ license {
     '**/com/hierynomus/sshj/userauth/keyprovider/bcrypt/*.java',
     '**/files/test_file_*.txt',
   ])
-}
-
-java {
-	withJavadocJar()
-	withSourcesJar()
 }
 
 if (!JavaVersion.current().isJava9Compatible()) {
@@ -98,6 +101,8 @@ testing {
         implementation "org.apache.sshd:sshd-sftp:$sshdVersion"
         implementation "org.apache.sshd:sshd-scp:$sshdVersion"
         implementation "ch.qos.logback:logback-classic:1.5.18"
+        implementation "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
+        implementation "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
       }
 
       targets {


### PR DESCRIPTION
This pull request assigns Bouncy Castle dependencies to the `bouncyCastle` [feature variant](https://docs.gradle.org/current/userguide/how_to_create_feature_variants_of_a_library.html) in the Gradle build. Assigning these dependencies to a variant results in marking the libraries as [optional dependencies](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html) in the published Maven configuration.

This change builds on recent efforts to move away from and isolate use of the Bouncy Castle library throughout the project.

This could be considered a breaking change for consumers that rely on inclusion of Bouncy Castle as a transitive dependency and require features that Bouncy Castle provides.

Direct features include reading PEM key files encrypted using historical methods other than PKCS8, and reading PuTTY Key Version 3 files that require the Argon2 key derivation function. Indirect features that depend on the Bouncy Castle security provider include support for Ed25519 when running on Java 14 or earlier, and support for X25519 when running on Java 10 or earlier. All of these features will continue to work when Bouncy Castle dependencies are declared directly.

The alternative to this change is retaining the current dependency requirements, and requiring consumers to exclude the Bouncy Castle transitive dependencies.