### PR TITLE
Upgrade dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ def bouncycastleVersion = "1.80"
 def sshdVersion = "2.14.0"
 
 dependencies {
-  implementation "org.slf4j:slf4j-api:2.0.16"
+  implementation "org.slf4j:slf4j-api:2.0.17"
   implementation "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
   implementation "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
   implementation "com.hierynomus:asn-one:0.6.0"
@@ -91,13 +91,13 @@ testing {
       dependencies {
         implementation "org.slf4j:slf4j-api:2.0.16"
         implementation 'org.spockframework:spock-core:2.3-groovy-3.0'
-        implementation "org.mockito:mockito-core:4.11.0"
-        implementation "org.assertj:assertj-core:3.24.2"
+        implementation "org.mockito:mockito-core:5.16.1"
+        implementation "org.assertj:assertj-core:3.27.3"
         implementation "ru.vyarus:spock-junit5:1.2.0"
         implementation "org.apache.sshd:sshd-core:$sshdVersion"
         implementation "org.apache.sshd:sshd-sftp:$sshdVersion"
         implementation "org.apache.sshd:sshd-scp:$sshdVersion"
-        implementation "ch.qos.logback:logback-classic:1.3.15"
+        implementation "ch.qos.logback:logback-classic:1.5.18"
         implementation 'org.glassfish.grizzly:grizzly-http-server:3.0.1'
       }
 
@@ -133,8 +133,8 @@ testing {
     integrationTest(JvmTestSuite) {
       dependencies {
         implementation project()
-        implementation 'org.testcontainers:testcontainers:1.20.4'
-        implementation 'org.testcontainers:junit-jupiter:1.20.4'
+        implementation platform('org.testcontainers:testcontainers-bom:1.20.6')
+        implementation 'org.testcontainers:junit-jupiter'
       }
 
       sources {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR upgrades dependencies to the latest stable versions:

- Upgrade Gradle to 8.13
- Upgrade SLF4J to 2.0.17
- Upgrade Mockito to 5.16.1
- Upgrade AssertJ to 3.27.3
- Upgrade Logback to 1.5.18
- Upgrade Testcontainers to 1.20.6