### PR TITLE
Upgrade SSHD from 2.14.0 to 2.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ compileJava {
 configurations.implementation.transitive = false
 
 def bouncycastleVersion = "1.80"
-def sshdVersion = "2.14.0"
+def sshdVersion = "2.15.0"
 
 dependencies {
   implementation "org.slf4j:slf4j-api:2.0.17"
@@ -89,7 +89,7 @@ testing {
     configureEach {
       useJUnitJupiter()
       dependencies {
-        implementation "org.slf4j:slf4j-api:2.0.16"
+        implementation "org.slf4j:slf4j-api:2.0.17"
         implementation 'org.spockframework:spock-core:2.3-groovy-3.0'
         implementation "org.mockito:mockito-core:5.16.1"
         implementation "org.assertj:assertj-core:3.27.3"


### PR DESCRIPTION
This pull request upgrades Apache SSHD dependencies from 2.14.0 to [2.15.0](https://mina.apache.org/sshd-project/download_2.15.0.html), incorporating several features and fixes for tests.

This pull request also upgrades the SLF4J version referenced under integration test dependencies to align with the main project version of 2.0.17.