### PR TITLE
Replace Grizzly HTTP Server with Java HTTP Server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,6 @@ testing {
         implementation "org.apache.sshd:sshd-sftp:$sshdVersion"
         implementation "org.apache.sshd:sshd-scp:$sshdVersion"
         implementation "ch.qos.logback:logback-classic:1.5.18"
-        implementation 'org.glassfish.grizzly:grizzly-http-server:3.0.1'
       }
 
       targets {


### PR DESCRIPTION
This pull request replaces the Grizzly HTTP Server dependency with the standard Java [HttpServer](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.httpserver/com/sun/net/httpserver/HttpServer.html) for port forwarding unit tests.

The Java HttpServer is part of the standard JDK since Java 1.6 and requires no external dependencies.