### PR TITLE
Update bouncycastle to v1.84

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ compileJava {
 
 configurations.implementation.transitive = false
 
-def bouncycastleVersion = "1.80"
+def bouncycastleVersion = "1.84"
 def sshdVersion = "2.15.0"
 
 dependencies {


### PR DESCRIPTION
This addresses three CVEs:

1. https://github.com/advisories/GHSA-wg6q-6289-32hp
2. https://github.com/advisories/GHSA-c3fc-8qff-9hwx
3. https://github.com/advisories/GHSA-p93r-85wp-75v3