### PR TITLE
Fix NullPointer in `DefaultConfig` error logging

### DIFF
--- a/src/main/java/net/schmizz/sshj/DefaultConfig.java
+++ b/src/main/java/net/schmizz/sshj/DefaultConfig.java
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.ListIterator;
+import java.util.Optional;
 import java.util.Properties;
 
 /**
@@ -162,8 +163,8 @@ public class DefaultConfig
         );
     }
 
-    protected void initCipherFactories() {
-        List<Factory.Named<Cipher>> avail = new LinkedList<Factory.Named<Cipher>>(Arrays.<Factory.Named<Cipher>>asList(
+    protected List<Factory.Named<Cipher>> getDefaultCipherFactories() {
+        return new LinkedList<>(Arrays.<Factory.Named<Cipher>>asList(
                 ChachaPolyCiphers.CHACHA_POLY_OPENSSH(),
                 BlockCiphers.AES128CBC(),
                 BlockCiphers.AES128CTR(),
@@ -198,6 +199,10 @@ public class DefaultConfig
                 StreamCiphers.Arcfour128(),
                 StreamCiphers.Arcfour256())
         );
+    }
+
+    protected void initCipherFactories() {
+        List<Factory.Named<Cipher>> avail = getDefaultCipherFactories();
 
         final ListIterator<Factory.Named<Cipher>> factories = avail.listIterator();
         while (factories.hasNext()) {
@@ -208,7 +213,7 @@ public class DefaultConfig
                 final byte[] iv = new byte[cipher.getIVSize()];
                 cipher.init(Cipher.Mode.Encrypt, key, iv);
             } catch (Exception e) {
-                log.info("Cipher [{}] disabled: {}", factory.getName(), e.getCause().getMessage());
+                log.info("Cipher [{}] disabled: {}", factory.getName(), Optional.ofNullable(e.getCause()).map(Throwable::getMessage), e);
                 factories.remove();
             }
         }

--- a/src/test/java/net/schmizz/sshj/DefaultSecurityProviderConfigTest.java
+++ b/src/test/java/net/schmizz/sshj/DefaultSecurityProviderConfigTest.java
@@ -15,13 +15,17 @@
  */
 package net.schmizz.sshj;
 
+import net.schmizz.sshj.common.Factory;
 import net.schmizz.sshj.common.SecurityUtils;
+import net.schmizz.sshj.transport.cipher.Cipher;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.security.Provider;
 import java.security.Security;
 import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterAll;
@@ -52,6 +56,37 @@ public class DefaultSecurityProviderConfigTest {
         new DefaultSecurityProviderConfig();
 
         assertBouncyCastleNotRegistered();
+    }
+
+    @Test
+    public void testCipherFactoryExceptionWithoutCause() {
+        final String failingCipherName = "failing-cipher-no-cause";
+
+        DefaultConfig config = new DefaultConfig() {
+            @Override
+            protected List<Factory.Named<Cipher>> getDefaultCipherFactories() {
+                List<Factory.Named<Cipher>> avail = super.getDefaultCipherFactories();
+                avail.add(0, new Factory.Named<Cipher>() {
+                    @Override
+                    public String getName() {
+                        return failingCipherName;
+                    }
+
+                    @Override
+                    public Cipher create() {
+                        throw new RuntimeException("test error with no cause");
+                    }
+                });
+                return avail;
+            }
+        };
+
+        boolean failingCipherPresent = config.getCipherFactories().stream()
+                .map(Factory.Named::getName)
+                .anyMatch(failingCipherName::equals);
+
+        assertFalse(failingCipherPresent,
+                "Cipher factory throwing exception without cause should be removed from available ciphers");
     }
 
     private void assertBouncyCastleNotRegistered() {


### PR DESCRIPTION
We have seen this causing an issue when the Exception was missing a Cause.
The error logging is extended so we don't miss anything.
A bit of refactor to make it easily testable.