### PR TITLE
Add FIDO2/U2F security key (sk-*) support and ssh-agent authentication

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -57,6 +57,8 @@ In the `examples` directory, there is a separate Maven project that shows how th
 
 * reading known_hosts files for host key verification
 * publickey, password and keyboard-interactive authentication
+* FIDO/U2F security keys (`sk-ecdsa-sha2-nistp256@openssh.com`, `sk-ssh-ed25519@openssh.com`), via an SSH agent or a pluggable `SecurityKeySigner`
+* SSH agent authentication over the `SSH_AUTH_SOCK` unix-domain socket
 * command, subsystem and shell channels
 * local and remote port forwarding
 * scp + complete sftp version 0-3 implementation
@@ -79,7 +81,8 @@ key exchange::
   `diffie-hellman-group16-sha256`, `diffie-hellman-group16-sha384@ssh.com`, `diffie-hellman-group16-sha512@ssh.com`, `diffie-hellman-group18-sha512@ssh.com`
 
 signatures::
-  `ssh-rsa`, `ssh-dss`, `ecdsa-sha2-nistp256`, `ecdsa-sha2-nistp384`, `ecdsa-sha2-nistp521`, `ssh-ed25519`, `ssh-rsa2-256`, `ssh-rsa2-512`
+  `ssh-rsa`, `ssh-dss`, `ecdsa-sha2-nistp256`, `ecdsa-sha2-nistp384`, `ecdsa-sha2-nistp521`, `ssh-ed25519`, `ssh-rsa2-256`, `ssh-rsa2-512`,
+  `sk-ecdsa-sha2-nistp256@openssh.com`, `sk-ssh-ed25519@openssh.com` (FIDO/U2F security keys)
 
 mac::
   `hmac-md5`, `hmac-md5-96`, `hmac-sha1`, `hmac-sha1-96`, `hmac-sha2-256`, `hmac-sha2-512`, `hmac-ripemd160`, `hmac-ripemd160@openssh.com`
@@ -89,7 +92,7 @@ compression::
   `zlib` and `zlib@openssh.com` (delayed zlib)
 
 private key files::
-   `pkcs5`, `pkcs8`, `openssh-key-v1`, `ssh-rsa-cert-v01@openssh.com`, `ssh-dsa-cert-v01@openssh.com`
+   `pkcs5`, `pkcs8`, `openssh-key-v1` (including FIDO/U2F `sk-ecdsa-sha2-nistp256@openssh.com` and `sk-ssh-ed25519@openssh.com` keys), `ssh-rsa-cert-v01@openssh.com`, `ssh-dsa-cert-v01@openssh.com`
 
 If you need something that is not included, it shouldn't be too hard to add (do contribute it!)
 

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,8 @@ testing {
         implementation "org.apache.sshd:sshd-core:$sshdVersion"
         implementation "org.apache.sshd:sshd-sftp:$sshdVersion"
         implementation "org.apache.sshd:sshd-scp:$sshdVersion"
+        // Apache MINA's sk-ssh-ed25519 verifier (used only by interop tests) delegates to net.i2p.crypto.eddsa.
+        implementation "net.i2p.crypto:eddsa:0.3.0"
         implementation "ch.qos.logback:logback-classic:1.5.18"
       }
 

--- a/examples/src/main/java/net/schmizz/sshj/examples/SecurityKeyAgentAuth.java
+++ b/examples/src/main/java/net/schmizz/sshj/examples/SecurityKeyAgentAuth.java
@@ -1,0 +1,42 @@
+package net.schmizz.sshj.examples;
+
+import com.hierynomus.sshj.userauth.agent.AgentProxy;
+import com.hierynomus.sshj.userauth.agent.AuthAgent;
+import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.connection.channel.direct.Session;
+
+import java.io.IOException;
+
+/**
+ * Authenticates with a FIDO/U2F security key (e.g. a YubiKey holding an {@code ed25519-sk} or
+ * {@code ecdsa-sk} key) by delegating to the system SSH agent.
+ * <p>
+ * Load the key into your agent once, then run this:
+ * <pre>
+ *   ssh-add ~/.ssh/id_ed25519_sk     # tap the key once to register it with the agent
+ *   ./run SecurityKeyAgentAuth
+ * </pre>
+ * The agent performs the hardware tap on every authentication, so sshj never has to talk to the
+ * authenticator directly. This also works for ordinary RSA/ECDSA/Ed25519 keys held by the agent.
+ */
+public class SecurityKeyAgentAuth {
+
+    public static void main(String... args) throws IOException {
+        final SSHClient ssh = new SSHClient();
+        ssh.loadKnownHosts();
+        ssh.connect("localhost");
+        // AgentProxy.fromEnvironment() connects to $SSH_AUTH_SOCK (requires a Java 16+ runtime for
+        // unix-domain sockets; supply your own AgentConnection on older JVMs or other platforms).
+        try (AgentProxy agent = AgentProxy.fromEnvironment()) {
+            ssh.auth(System.getProperty("user.name"), AuthAgent.fromIdentities(agent));
+            final Session session = ssh.startSession();
+            try {
+                session.exec("echo authenticated with a security key").join();
+            } finally {
+                session.close();
+            }
+        } finally {
+            ssh.disconnect();
+        }
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/key/KeyAlgorithms.java
+++ b/src/main/java/com/hierynomus/sshj/key/KeyAlgorithms.java
@@ -16,6 +16,8 @@
 package com.hierynomus.sshj.key;
 
 import com.hierynomus.sshj.signature.SignatureEdDSA;
+import com.hierynomus.sshj.signature.SignatureSkEcdsa;
+import com.hierynomus.sshj.signature.SignatureSkEd25519;
 import net.schmizz.sshj.common.KeyType;
 import net.schmizz.sshj.signature.Signature;
 import net.schmizz.sshj.signature.SignatureDSA;
@@ -38,6 +40,8 @@ public class KeyAlgorithms {
     public static Factory ECDSASHANistp521CertV01() { return new Factory(KeyType.ECDSA521_CERT.toString(), new SignatureECDSA.Factory521(), KeyType.ECDSA521_CERT); }
     public static Factory EdDSA25519() { return new Factory(KeyType.ED25519.toString(), new SignatureEdDSA.Factory(), KeyType.ED25519); }
     public static Factory EdDSA25519CertV01() { return new Factory(KeyType.ED25519_CERT.toString(), new SignatureEdDSA.Factory(), KeyType.ED25519_CERT); }
+    public static Factory SkSSHEd25519() { return new Factory(KeyType.SK_ED25519.toString(), new SignatureSkEd25519.Factory(), KeyType.SK_ED25519); }
+    public static Factory SkECDSANistp256() { return new Factory(KeyType.SK_ECDSA.toString(), new SignatureSkEcdsa.Factory(), KeyType.SK_ECDSA); }
 
     public static class Factory implements net.schmizz.sshj.common.Factory.Named<KeyAlgorithm> {
 

--- a/src/main/java/com/hierynomus/sshj/signature/AbstractSecurityKeySignature.java
+++ b/src/main/java/com/hierynomus/sshj/signature/AbstractSecurityKeySignature.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.signature;
+
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPrivateKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPublicKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySignatureData;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySigner;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySigningRequest;
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.SSHRuntimeException;
+import net.schmizz.sshj.signature.AbstractSignatureDSA;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SignatureException;
+
+/**
+ * Base class for the OpenSSH FIDO/U2F security key signatures
+ * ({@code sk-ecdsa-sha2-nistp256@openssh.com} and {@code sk-ssh-ed25519@openssh.com}).
+ * <p>
+ * The difference from an ordinary SSH signature is what actually gets signed. A FIDO authenticator
+ * never sees the SSH payload directly; instead it signs a small fixed structure (WebAuthn calls it
+ * the authenticator data plus the client-data hash):
+ *
+ * <pre>
+ *   signed = SHA256(application) || flags || counter || SHA256(sshData)
+ * </pre>
+ *
+ * and the wire signature carries the {@code flags} and {@code counter} so the verifier can rebuild
+ * that structure:
+ *
+ * <pre>
+ *   string  key type
+ *   string  raw signature        (ECDSA r||s as two mpints, or 64-byte Ed25519 signature)
+ *   byte    flags
+ *   uint32  counter
+ * </pre>
+ *
+ * Verification rebuilds {@code signed} and checks it with the underlying ECDSA/Ed25519 key. Signing
+ * is delegated to a {@link SecurityKeySigner} (the hardware bridge); this class only hashes the SSH
+ * payload, hands the challenge to the signer and assembles the wire format from what comes back.
+ *
+ * @see <a href="https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.u2f">PROTOCOL.u2f</a>
+ */
+public abstract class AbstractSecurityKeySignature extends AbstractSignatureDSA {
+
+    private final ByteArrayOutputStream sshData = new ByteArrayOutputStream();
+    private String application;
+    private SecurityKeyPrivateKey signingKey;
+    private byte signedFlags;
+    private long signedCounter;
+
+    protected AbstractSecurityKeySignature(String algorithm, String keyTypeName) {
+        super(algorithm, keyTypeName);
+    }
+
+    @Override
+    public void initVerify(PublicKey publicKey) {
+        if (!(publicKey instanceof SecurityKeyPublicKey)) {
+            throw new SSHRuntimeException("Expected a SecurityKeyPublicKey but got: " + publicKey);
+        }
+        SecurityKeyPublicKey sk = (SecurityKeyPublicKey) publicKey;
+        this.application = sk.getApplication();
+        super.initVerify(sk.getDelegate());
+    }
+
+    @Override
+    public void initSign(PrivateKey privateKey) {
+        if (!(privateKey instanceof SecurityKeyPrivateKey)) {
+            throw new SSHRuntimeException("Expected a SecurityKeyPrivateKey but got: " + privateKey);
+        }
+        this.signingKey = (SecurityKeyPrivateKey) privateKey;
+        this.application = signingKey.getApplication();
+    }
+
+    @Override
+    public void update(byte[] foo, int off, int len) {
+        sshData.write(foo, off, len);
+    }
+
+    @Override
+    public byte[] sign() {
+        if (signingKey == null) {
+            throw new SSHRuntimeException("initSign was not called with a SecurityKeyPrivateKey");
+        }
+        SecurityKeySigner signer = signingKey.getSigner();
+        if (signer == null) {
+            throw new SSHRuntimeException("No SecurityKeySigner attached to security key " + signingKey.getKeyTypeName()
+                    + "; cannot reach the authenticator. Authenticate via ssh-agent or attach a SecurityKeySigner.");
+        }
+        byte[] challenge = sha256(sshData.toByteArray());
+        SecurityKeySignatureData data;
+        try {
+            data = signer.sign(new SecurityKeySigningRequest(signingKey.getKeyTypeName(), application,
+                    signingKey.getKeyHandle(), challenge, signingKey.getFlags()));
+        } catch (IOException e) {
+            throw new SSHRuntimeException("Security key signing failed", e);
+        }
+        this.signedFlags = data.getFlags();
+        this.signedCounter = data.getCounter();
+        return deviceSignatureToSsh(data.getSignature());
+    }
+
+    /**
+     * Assemble the full SSH signature value: {@code string keyType || string rawSig || byte flags || uint32 counter}.
+     * Relies on {@link #sign()} having been called first to capture the flags and counter.
+     */
+    @Override
+    public byte[] encode(byte[] sshRawSignature) {
+        return new Buffer.PlainBuffer()
+                .putString(getSignatureName())
+                .putBytes(sshRawSignature)
+                .putByte(signedFlags)
+                .putUInt32(signedCounter)
+                .getCompactData();
+    }
+
+    @Override
+    public boolean verify(byte[] sig) {
+        Buffer.PlainBuffer buf = new Buffer.PlainBuffer(sig);
+        try {
+            String type = buf.readString();
+            if (!getSignatureName().equals(type)) {
+                throw new SSHRuntimeException("Expected '" + getSignatureName() + "' signature but got: " + type);
+            }
+            byte[] sshRawSignature = buf.readBytes();
+            byte flags = buf.readByte();
+            long counter = buf.readUInt32();
+
+            byte[] signedData = buildSignedData(flags, counter, sha256(sshData.toByteArray()));
+            signature.update(signedData);
+            return signature.verify(sshSignatureToDevice(sshRawSignature));
+        } catch (Buffer.BufferException | SignatureException e) {
+            throw new SSHRuntimeException(e);
+        }
+    }
+
+    /**
+     * The exact bytes the authenticator signs: {@code SHA256(application) || flags || counter || clientDataHash}.
+     */
+    private byte[] buildSignedData(byte flags, long counter, byte[] clientDataHash) {
+        byte[] rpIdHash = sha256(application.getBytes(StandardCharsets.UTF_8));
+        return new Buffer.PlainBuffer()
+                .putRawBytes(rpIdHash)
+                .putByte(flags)
+                .putUInt32(counter)
+                .putRawBytes(clientDataHash)
+                .getCompactData();
+    }
+
+    protected static byte[] sha256(byte[] data) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(data);
+        } catch (NoSuchAlgorithmException e) {
+            throw new SSHRuntimeException(e);
+        }
+    }
+
+    /**
+     * Convert the SSH raw-signature encoding read off the wire into the byte format the JCA
+     * verification engine expects (DER for ECDSA, unchanged for Ed25519).
+     */
+    protected abstract byte[] sshSignatureToDevice(byte[] sshRawSignature) throws Buffer.BufferException;
+
+    /**
+     * Convert the authenticator's native signature into the SSH raw-signature encoding (r||s as two
+     * mpints for ECDSA, unchanged for Ed25519).
+     */
+    protected abstract byte[] deviceSignatureToSsh(byte[] deviceSignature);
+}

--- a/src/main/java/com/hierynomus/sshj/signature/SignatureSkEcdsa.java
+++ b/src/main/java/com/hierynomus/sshj/signature/SignatureSkEcdsa.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.signature;
+
+import com.hierynomus.asn1.ASN1InputStream;
+import com.hierynomus.asn1.encodingrules.der.DERDecoder;
+import com.hierynomus.asn1.types.constructed.ASN1Sequence;
+import com.hierynomus.asn1.types.primitive.ASN1Integer;
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.IOUtils;
+import net.schmizz.sshj.common.KeyType;
+import net.schmizz.sshj.common.SSHRuntimeException;
+import net.schmizz.sshj.signature.Signature;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+
+/**
+ * Signature for the {@code sk-ecdsa-sha2-nistp256@openssh.com} FIDO/U2F key type.
+ * <p>
+ * The authenticator produces an ASN.1 DER ECDSA signature; on the SSH wire it is encoded as the two
+ * integers {@code r} and {@code s} as mpints, exactly like a plain {@code ecdsa-sha2-nistp256}
+ * signature. This class converts between the two encodings. The verification engine is always
+ * SHA-256 (the "sha2-nistp256" of the key type).
+ */
+public class SignatureSkEcdsa extends AbstractSecurityKeySignature {
+
+    public static class Factory implements net.schmizz.sshj.common.Factory.Named<Signature> {
+        @Override
+        public String getName() {
+            return KeyType.SK_ECDSA.toString();
+        }
+
+        @Override
+        public Signature create() {
+            return new SignatureSkEcdsa();
+        }
+    }
+
+    public SignatureSkEcdsa() {
+        super("SHA256withECDSA", KeyType.SK_ECDSA.toString());
+    }
+
+    @Override
+    protected byte[] sshSignatureToDevice(byte[] sshRawSignature) throws Buffer.BufferException {
+        Buffer.PlainBuffer buf = new Buffer.PlainBuffer(sshRawSignature);
+        BigInteger r = buf.readMPInt();
+        BigInteger s = buf.readMPInt();
+        try {
+            return encodeAsnSignature(r, s);
+        } catch (IOException e) {
+            throw new SSHRuntimeException(e);
+        }
+    }
+
+    @Override
+    protected byte[] deviceSignatureToSsh(byte[] derSignature) {
+        ByteArrayInputStream bais = new ByteArrayInputStream(derSignature);
+        ASN1InputStream asn1InputStream = new ASN1InputStream(new DERDecoder(), bais);
+        try {
+            ASN1Sequence sequence = asn1InputStream.readObject();
+            BigInteger r = ((ASN1Integer) sequence.get(0)).getValue();
+            BigInteger s = ((ASN1Integer) sequence.get(1)).getValue();
+            return new Buffer.PlainBuffer().putMPInt(r).putMPInt(s).getCompactData();
+        } finally {
+            IOUtils.closeQuietly(asn1InputStream, bais);
+        }
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/signature/SignatureSkEd25519.java
+++ b/src/main/java/com/hierynomus/sshj/signature/SignatureSkEd25519.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.signature;
+
+import net.schmizz.sshj.common.KeyType;
+import net.schmizz.sshj.signature.Signature;
+
+/**
+ * Signature for the {@code sk-ssh-ed25519@openssh.com} FIDO/U2F key type. The raw Ed25519
+ * signature is used as-is in both directions.
+ */
+public class SignatureSkEd25519 extends AbstractSecurityKeySignature {
+
+    public static class Factory implements net.schmizz.sshj.common.Factory.Named<Signature> {
+        @Override
+        public String getName() {
+            return KeyType.SK_ED25519.toString();
+        }
+
+        @Override
+        public Signature create() {
+            return new SignatureSkEd25519();
+        }
+    }
+
+    public SignatureSkEd25519() {
+        super("Ed25519", KeyType.SK_ED25519.toString());
+    }
+
+    @Override
+    protected byte[] sshSignatureToDevice(byte[] sshRawSignature) {
+        return sshRawSignature;
+    }
+
+    @Override
+    protected byte[] deviceSignatureToSsh(byte[] deviceSignature) {
+        return deviceSignature;
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/AgentConnection.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/AgentConnection.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * A duplex byte channel to a running SSH authentication agent.
+ * <p>
+ * sshj ships {@link UnixSocketAgentConnection} for the {@code SSH_AUTH_SOCK} unix-domain socket
+ * used by OpenSSH on Linux and macOS. Implement this yourself to reach an agent over a different
+ * transport, e.g. a Windows named pipe / Pageant, or a socket your application already owns.
+ */
+public interface AgentConnection extends Closeable {
+
+    InputStream getInputStream() throws IOException;
+
+    OutputStream getOutputStream() throws IOException;
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/AgentIdentity.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/AgentIdentity.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import java.security.PublicKey;
+
+/**
+ * An identity held by an SSH agent: a public key, its exact wire encoding (the "key blob" that must
+ * be sent back verbatim in a sign request) and the human-readable comment.
+ */
+public class AgentIdentity {
+
+    private final PublicKey publicKey;
+    private final byte[] keyBlob;
+    private final String comment;
+
+    public AgentIdentity(PublicKey publicKey, byte[] keyBlob, String comment) {
+        this.publicKey = publicKey;
+        this.keyBlob = keyBlob;
+        this.comment = comment;
+    }
+
+    public PublicKey getPublicKey() {
+        return publicKey;
+    }
+
+    /** @return the exact key blob bytes as returned by the agent. */
+    public byte[] getKeyBlob() {
+        return keyBlob;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    @Override
+    public String toString() {
+        return "AgentIdentity{" + comment + ", " + publicKey.getAlgorithm() + "}";
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/AgentProxy.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/AgentProxy.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import net.schmizz.sshj.common.Buffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A client for the SSH authentication agent protocol (draft-miller-ssh-agent / OpenSSH's
+ * {@code PROTOCOL.agent}).
+ * <p>
+ * This is the recommended way to authenticate with a FIDO/U2F security key (an
+ * {@code sk-ecdsa-sha2-nistp256@openssh.com} or {@code sk-ssh-ed25519@openssh.com} key): load the
+ * key into your agent once with {@code ssh-add}, and the agent performs the hardware tap on every
+ * sign. The agent returns a fully formed SSH signature - including the security-key flags and
+ * counter - so sshj forwards it verbatim and never has to talk to the hardware itself.
+ * <p>
+ * It works for ordinary keys too (RSA, ECDSA, Ed25519), so it doubles as general ssh-agent support.
+ */
+public class AgentProxy implements Closeable {
+
+    private static final byte SSH_AGENT_FAILURE = 5;
+    private static final byte SSH_AGENTC_REQUEST_IDENTITIES = 11;
+    private static final byte SSH_AGENT_IDENTITIES_ANSWER = 12;
+    private static final byte SSH_AGENTC_SIGN_REQUEST = 13;
+    private static final byte SSH_AGENT_SIGN_RESPONSE = 14;
+
+    /** Sign flag asking the agent for an {@code rsa-sha2-256} signature from an RSA key. */
+    public static final int SSH_AGENT_RSA_SHA2_256 = 2;
+    /** Sign flag asking the agent for an {@code rsa-sha2-512} signature from an RSA key. */
+    public static final int SSH_AGENT_RSA_SHA2_512 = 4;
+
+    /** OpenSSH caps a single agent message at 256 KiB. */
+    private static final int AGENT_MAX_MESSAGE_LENGTH = 256 * 1024;
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final AgentConnection connection;
+    private final DataInputStream in;
+    private final OutputStream out;
+
+    public AgentProxy(AgentConnection connection) throws IOException {
+        this.connection = connection;
+        this.in = new DataInputStream(connection.getInputStream());
+        this.out = connection.getOutputStream();
+    }
+
+    /**
+     * Connect to the agent indicated by the {@code SSH_AUTH_SOCK} environment variable over a unix-
+     * domain socket. Requires a Java 16+ runtime; on older runtimes construct an {@link AgentProxy}
+     * with your own {@link AgentConnection}.
+     *
+     * @throws IOException if {@code SSH_AUTH_SOCK} is unset or the agent cannot be reached
+     */
+    public static AgentProxy fromEnvironment() throws IOException {
+        String socketPath = System.getenv("SSH_AUTH_SOCK");
+        if (socketPath == null || socketPath.isEmpty()) {
+            throw new IOException("SSH_AUTH_SOCK is not set; no SSH agent is available");
+        }
+        return new AgentProxy(new UnixSocketAgentConnection(socketPath));
+    }
+
+    /**
+     * List the identities the agent holds. Identities whose key type sshj does not understand are
+     * skipped (logged at debug), rather than failing the whole listing.
+     */
+    public synchronized List<AgentIdentity> getIdentities() throws IOException {
+        writeMessage(SSH_AGENTC_REQUEST_IDENTITIES, new byte[0]);
+        Response response = readMessage();
+        if (response.type != SSH_AGENT_IDENTITIES_ANSWER) {
+            throw new IOException("Unexpected response to agent identities request: type " + response.type);
+        }
+        Buffer.PlainBuffer buf = new Buffer.PlainBuffer(response.contents);
+        List<AgentIdentity> identities = new ArrayList<>();
+        try {
+            long count = buf.readUInt32();
+            for (long i = 0; i < count; i++) {
+                byte[] keyBlob = buf.readBytes();
+                String comment = buf.readString();
+                try {
+                    PublicKey publicKey = new Buffer.PlainBuffer(keyBlob).readPublicKey();
+                    identities.add(new AgentIdentity(publicKey, keyBlob, comment));
+                } catch (Exception e) {
+                    log.debug("Skipping agent identity '{}' of unsupported key type: {}", comment, e.toString());
+                }
+            }
+        } catch (Buffer.BufferException e) {
+            throw new IOException("Malformed agent identities answer", e);
+        }
+        return identities;
+    }
+
+    /**
+     * Ask the agent to sign {@code data} with the key identified by {@code keyBlob}.
+     *
+     * @param keyBlob the identity's key blob, exactly as returned by {@link #getIdentities()}
+     * @param data    the data to sign
+     * @param flags   sign flags, e.g. {@link #SSH_AGENT_RSA_SHA2_256}; {@code 0} for Ed25519 and
+     *                security keys
+     * @return the SSH signature value ({@code string signature_format || string signature_blob}, with
+     * any security-key flags and counter already appended by the agent), ready to be written as a
+     * single SSH {@code string}
+     */
+    public synchronized byte[] sign(byte[] keyBlob, byte[] data, int flags) throws IOException {
+        byte[] request = new Buffer.PlainBuffer()
+                .putBytes(keyBlob)
+                .putBytes(data)
+                .putUInt32(flags & 0xffffffffL)
+                .getCompactData();
+        writeMessage(SSH_AGENTC_SIGN_REQUEST, request);
+        Response response = readMessage();
+        if (response.type != SSH_AGENT_SIGN_RESPONSE) {
+            throw new IOException(response.type == SSH_AGENT_FAILURE
+                    ? "Agent declined to sign (it may not hold this key, or the user cancelled the touch/PIN)"
+                    : "Unexpected response to agent sign request: type " + response.type);
+        }
+        try {
+            return new Buffer.PlainBuffer(response.contents).readBytes();
+        } catch (Buffer.BufferException e) {
+            throw new IOException("Malformed agent sign response", e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        connection.close();
+    }
+
+    private void writeMessage(byte type, byte[] contents) throws IOException {
+        int length = 1 + contents.length;
+        byte[] header = new byte[]{
+                (byte) (length >>> 24), (byte) (length >>> 16), (byte) (length >>> 8), (byte) length, type
+        };
+        out.write(header);
+        out.write(contents);
+        out.flush();
+    }
+
+    private Response readMessage() throws IOException {
+        int length = in.readInt();
+        if (length <= 0 || length > AGENT_MAX_MESSAGE_LENGTH) {
+            throw new IOException("Illegal agent message length: " + length);
+        }
+        byte type = in.readByte();
+        byte[] contents = new byte[length - 1];
+        in.readFully(contents);
+        return new Response(type, contents);
+    }
+
+    private static final class Response {
+        private final byte type;
+        private final byte[] contents;
+
+        private Response(byte type, byte[] contents) {
+            this.type = type;
+            this.contents = contents;
+        }
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/AuthAgent.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/AuthAgent.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import com.hierynomus.sshj.key.KeyAlgorithm;
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.KeyType;
+import net.schmizz.sshj.common.Message;
+import net.schmizz.sshj.common.SSHPacket;
+import net.schmizz.sshj.transport.TransportException;
+import net.schmizz.sshj.userauth.UserAuthException;
+import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
+import net.schmizz.sshj.userauth.method.AuthMethod;
+import net.schmizz.sshj.userauth.method.KeyedAuthMethod;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The {@code "publickey"} authentication method backed by an SSH agent, for a single agent identity.
+ * <p>
+ * It behaves exactly like {@link net.schmizz.sshj.userauth.method.AuthPublickey} - send the public
+ * key, and on {@code SSH_MSG_USERAUTH_PK_OK} send a signed request - except the signature is
+ * produced by the {@link AgentProxy} (which drives the hardware, PIN and touch) and used verbatim.
+ * This is how FIDO/U2F security keys ({@code sk-*}) authenticate: the agent returns a complete
+ * signature with the security-key flags and counter already appended.
+ * <p>
+ * Use {@link #fromIdentities(AgentProxy)} to turn every identity the agent holds into a method:
+ * <pre>{@code
+ *   try (AgentProxy agent = AgentProxy.fromEnvironment()) {
+ *       ssh.auth(username, AuthAgent.fromIdentities(agent));
+ *   }
+ * }</pre>
+ */
+public class AuthAgent extends KeyedAuthMethod {
+
+    private final AgentProxy agent;
+    private final AgentIdentity identity;
+
+    public AuthAgent(AgentProxy agent, AgentIdentity identity) {
+        super("publickey", new AgentKeyProvider(identity));
+        this.agent = agent;
+        this.identity = identity;
+    }
+
+    /**
+     * Build one {@link AuthAgent} method per identity the agent currently holds, ready to hand to
+     * {@link net.schmizz.sshj.SSHClient#auth(String, Iterable)}.
+     */
+    public static List<AuthMethod> fromIdentities(AgentProxy agent) throws IOException {
+        List<AuthMethod> methods = new ArrayList<>();
+        for (AgentIdentity identity : agent.getIdentities()) {
+            methods.add(new AuthAgent(agent, identity));
+        }
+        return methods;
+    }
+
+    @Override
+    public void handle(Message cmd, SSHPacket buf) throws UserAuthException, TransportException {
+        if (cmd == Message.USERAUTH_60) {
+            sendSignedRequest();
+        } else {
+            super.handle(cmd, buf);
+        }
+    }
+
+    @Override
+    protected SSHPacket buildReq() throws UserAuthException {
+        // Feeler request, no signature.
+        return putPubKey(super.buildReq().putBoolean(false));
+    }
+
+    private void sendSignedRequest() throws UserAuthException, TransportException {
+        SSHPacket req = putPubKey(super.buildReq().putBoolean(true));
+        byte[] dataToSign = new Buffer.PlainBuffer()
+                .putString(params.getTransport().getSessionID())
+                .putBuffer(req)
+                .getCompactData();
+        byte[] signature;
+        try {
+            signature = agent.sign(identity.getKeyBlob(), dataToSign, agentSignFlags());
+        } catch (IOException e) {
+            throw new UserAuthException("SSH agent failed to sign for " + identity, e);
+        }
+        // The agent returns a fully formed SSH signature value; write it as a single string.
+        req.putString(signature);
+        params.getTransport().write(req);
+    }
+
+    @Override
+    protected SSHPacket putPubKey(SSHPacket reqBuf) throws UserAuthException {
+        KeyType keyType = identityType();
+        try {
+            KeyAlgorithm keyAlgorithm = getPublicKeyAlgorithm(keyType);
+            if (keyAlgorithm == null) {
+                throw new UserAuthException("No KeyAlgorithm configured for agent key " + keyType);
+            }
+            // Use the exact key blob the agent gave us, so signature verification matches byte-for-byte.
+            reqBuf.putString(keyAlgorithm.getKeyAlgorithm()).putString(identity.getKeyBlob());
+            return reqBuf;
+        } catch (TransportException e) {
+            throw new UserAuthException("No KeyAlgorithm configured for agent key " + keyType, e);
+        }
+    }
+
+    private int agentSignFlags() throws UserAuthException {
+        try {
+            KeyAlgorithm keyAlgorithm = getPublicKeyAlgorithm(identityType());
+            String name = keyAlgorithm == null ? "" : keyAlgorithm.getKeyAlgorithm();
+            if ("rsa-sha2-512".equals(name)) {
+                return AgentProxy.SSH_AGENT_RSA_SHA2_512;
+            }
+            if ("rsa-sha2-256".equals(name)) {
+                return AgentProxy.SSH_AGENT_RSA_SHA2_256;
+            }
+            return 0;
+        } catch (TransportException e) {
+            throw new UserAuthException("Could not resolve key algorithm for agent key", e);
+        }
+    }
+
+    private KeyType identityType() {
+        return KeyType.fromKey(identity.getPublicKey());
+    }
+
+    /** Exposes the agent identity's public key to {@link KeyedAuthMethod}; signing happens via the agent. */
+    private static final class AgentKeyProvider implements KeyProvider {
+        private final AgentIdentity identity;
+
+        private AgentKeyProvider(AgentIdentity identity) {
+            this.identity = identity;
+        }
+
+        @Override
+        public PrivateKey getPrivate() {
+            throw new UnsupportedOperationException("Agent-held keys are signed by the agent, not locally");
+        }
+
+        @Override
+        public PublicKey getPublic() {
+            return identity.getPublicKey();
+        }
+
+        @Override
+        public KeyType getType() {
+            return KeyType.fromKey(identity.getPublicKey());
+        }
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/UnixSocketAgentConnection.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/UnixSocketAgentConnection.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.net.SocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
+
+/**
+ * An {@link AgentConnection} over a unix-domain socket, as used by OpenSSH's {@code SSH_AUTH_SOCK}
+ * on Linux and macOS.
+ * <p>
+ * Unix-domain sockets are only in the JDK from Java 16 onwards. sshj's main sources target Java 8,
+ * so the Java 16 socket classes are reached reflectively here: this compiles everywhere and works
+ * at runtime on a Java 16+ JVM (such as the JetBrains Runtime). On an older runtime the constructor
+ * throws an {@link IOException} explaining that you must supply your own {@link AgentConnection}.
+ */
+public class UnixSocketAgentConnection implements AgentConnection {
+
+    private final SocketChannel channel;
+    private final InputStream in;
+    private final OutputStream out;
+
+    public UnixSocketAgentConnection(String socketPath) throws IOException {
+        this.channel = openUnixSocketChannel(socketPath);
+        this.in = Channels.newInputStream(channel);
+        this.out = Channels.newOutputStream(channel);
+    }
+
+    private static SocketChannel openUnixSocketChannel(String socketPath) throws IOException {
+        try {
+            // Equivalent to (Java 16+):
+            //   SocketChannel ch = SocketChannel.open(StandardProtocolFamily.UNIX);
+            //   ch.connect(UnixDomainSocketAddress.of(socketPath));
+            Class<?> standardProtocolFamily = Class.forName("java.net.StandardProtocolFamily");
+            Object unix = standardProtocolFamily.getField("UNIX").get(null);
+
+            Class<?> unixDomainSocketAddress = Class.forName("java.net.UnixDomainSocketAddress");
+            SocketAddress address = (SocketAddress) unixDomainSocketAddress
+                    .getMethod("of", String.class).invoke(null, socketPath);
+
+            Method open = SocketChannel.class.getMethod("open", Class.forName("java.net.ProtocolFamily"));
+            SocketChannel channel = (SocketChannel) open.invoke(null, unix);
+            try {
+                channel.connect(address);
+            } catch (IOException e) {
+                channel.close();
+                throw e;
+            }
+            return channel;
+        } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException e) {
+            throw new IOException("Unix-domain socket support requires a Java 16+ runtime. "
+                    + "On an older runtime, connect to the agent yourself and pass a custom AgentConnection.", e);
+        } catch (ReflectiveOperationException e) {
+            throw new IOException("Failed to open unix-domain socket to SSH agent at " + socketPath, e);
+        }
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return in;
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return out;
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/fido/SecurityKeyPrivateKey.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/fido/SecurityKeyPrivateKey.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.fido;
+
+import java.security.PrivateKey;
+
+/**
+ * The "private" half of an OpenSSH FIDO/U2F security key.
+ * <p>
+ * Unlike a normal private key this holds no secret scalar: the secret never leaves the hardware
+ * authenticator. What an {@code sk-*} private key file actually stores - and what this class carries
+ * - is the {@link #getApplication() application}, the {@link #getKeyHandle() key handle} (credential
+ * id) and the authenticator {@link #getFlags() flags}. Signing is delegated to a
+ * {@link SecurityKeySigner}, which drives the hardware.
+ *
+ * @see SecurityKeySigner
+ */
+public class SecurityKeyPrivateKey implements PrivateKey {
+    private static final long serialVersionUID = 1L;
+
+    private final String keyTypeName;
+    private final SecurityKeyPublicKey publicKey;
+    private final byte flags;
+    private final byte[] keyHandle;
+    private final transient SecurityKeySigner signer;
+
+    public SecurityKeyPrivateKey(String keyTypeName, SecurityKeyPublicKey publicKey, byte flags, byte[] keyHandle, SecurityKeySigner signer) {
+        this.keyTypeName = keyTypeName;
+        this.publicKey = publicKey;
+        this.flags = flags;
+        this.keyHandle = keyHandle;
+        this.signer = signer;
+    }
+
+    /** @return the SSH key type, e.g. {@code sk-ssh-ed25519@openssh.com}. */
+    public String getKeyTypeName() {
+        return keyTypeName;
+    }
+
+    public SecurityKeyPublicKey getPublicKey() {
+        return publicKey;
+    }
+
+    public String getApplication() {
+        return publicKey.getApplication();
+    }
+
+    /** @return the authenticator flags the key was created with (user-presence / user-verification). */
+    public byte getFlags() {
+        return flags;
+    }
+
+    public byte[] getKeyHandle() {
+        return keyHandle;
+    }
+
+    /** @return the bridge to the hardware authenticator, or {@code null} if none was attached. */
+    public SecurityKeySigner getSigner() {
+        return signer;
+    }
+
+    @Override
+    public String getAlgorithm() {
+        return publicKey.getAlgorithm();
+    }
+
+    @Override
+    public String getFormat() {
+        // No standard encoding: the key material is opaque and lives in the authenticator.
+        return null;
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        return null;
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/fido/SecurityKeyPublicKey.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/fido/SecurityKeyPublicKey.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.fido;
+
+import java.security.PublicKey;
+import java.util.Objects;
+
+/**
+ * A public key for an OpenSSH FIDO/U2F security key, i.e. one of the
+ * {@code sk-ecdsa-sha2-nistp256@openssh.com} or {@code sk-ssh-ed25519@openssh.com} key types.
+ * <p>
+ * Such a key is a regular ECDSA (NIST P-256) or Ed25519 public key with an additional
+ * {@code application} string attached (typically {@code "ssh:"}). The application string is part of
+ * the SSH wire encoding of the key and is mixed into every signature the authenticator produces, so
+ * it has to travel with the key. This wrapper keeps the underlying {@link PublicKey} and the
+ * application together.
+ * <p>
+ * It deliberately does <em>not</em> implement {@link java.security.interfaces.ECKey} or
+ * {@code EdECKey} so that {@link net.schmizz.sshj.common.KeyType#fromKey(java.security.Key)} can tell
+ * a security-key public key apart from a plain ECDSA/Ed25519 public key.
+ *
+ * @see <a href="https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.u2f">PROTOCOL.u2f</a>
+ */
+public class SecurityKeyPublicKey implements PublicKey {
+    private static final long serialVersionUID = 1L;
+
+    private final PublicKey delegate;
+    private final String application;
+
+    public SecurityKeyPublicKey(PublicKey delegate, String application) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate public key");
+        this.application = Objects.requireNonNull(application, "application");
+    }
+
+    /** @return the underlying ECDSA (P-256) or Ed25519 public key. */
+    public PublicKey getDelegate() {
+        return delegate;
+    }
+
+    /** @return the application string, e.g. {@code "ssh:"}. */
+    public String getApplication() {
+        return application;
+    }
+
+    @Override
+    public String getAlgorithm() {
+        return delegate.getAlgorithm();
+    }
+
+    @Override
+    public String getFormat() {
+        return delegate.getFormat();
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        // The application string is only part of the SSH wire encoding (see KeyType), not of the
+        // JCA X.509 encoding. Callers that need the SSH blob must go through KeyType#putPubKeyIntoBuffer.
+        return delegate.getEncoded();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SecurityKeyPublicKey)) {
+            return false;
+        }
+        SecurityKeyPublicKey that = (SecurityKeyPublicKey) o;
+        return delegate.equals(that.delegate) && application.equals(that.application);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate, application);
+    }
+
+    @Override
+    public String toString() {
+        return "SecurityKeyPublicKey{application=" + application + ", delegate=" + delegate + "}";
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/fido/SecurityKeySignatureData.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/fido/SecurityKeySignatureData.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.fido;
+
+/**
+ * The result of a {@link SecurityKeySigner} assertion: what the authenticator reported back.
+ */
+public class SecurityKeySignatureData {
+
+    private final byte flags;
+    private final long counter;
+    private final byte[] signature;
+
+    /**
+     * @param flags     the authenticator data flags the device returned (user-presence, user-verified, ...)
+     * @param counter   the signature counter the device returned (an unsigned 32-bit value)
+     * @param signature the raw signature the device produced: an ASN.1 DER ECDSA signature for
+     *                  {@code sk-ecdsa-sha2-nistp256@openssh.com}, or the raw 64-byte Ed25519
+     *                  signature for {@code sk-ssh-ed25519@openssh.com}
+     */
+    public SecurityKeySignatureData(byte flags, long counter, byte[] signature) {
+        this.flags = flags;
+        this.counter = counter;
+        this.signature = signature;
+    }
+
+    public byte getFlags() {
+        return flags;
+    }
+
+    public long getCounter() {
+        return counter;
+    }
+
+    public byte[] getSignature() {
+        return signature;
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/fido/SecurityKeySigner.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/fido/SecurityKeySigner.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.fido;
+
+import java.io.IOException;
+
+/**
+ * Service provider interface for signing with an OpenSSH FIDO/U2F security key (an
+ * {@code sk-ecdsa-sha2-nistp256@openssh.com} or {@code sk-ssh-ed25519@openssh.com} key).
+ * <p>
+ * sshj cannot talk to a hardware authenticator on its own: there is no pure-Java USB-HID / CTAP
+ * stack. The embedding application supplies one of these to bridge to the hardware - for example
+ * via libfido2, a platform WebAuthn API, or by delegating to a running ssh-agent. Given the
+ * challenge to sign, the application string and the credential (key handle), an implementation
+ * makes the authenticator produce an assertion and returns the device's signature plus the flags
+ * and counter that the authenticator reported.
+ * <p>
+ * Note: when a {@code ssh-agent} holds the security key, you do not need this interface at all - the
+ * agent returns a fully formed SSH signature. Use the {@code com.hierynomus.sshj.userauth.agent}
+ * support instead. This SPI is for applications that drive the authenticator themselves.
+ *
+ * @see <a href="https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.u2f">PROTOCOL.u2f</a>
+ */
+public interface SecurityKeySigner {
+
+    /**
+     * Produce a FIDO assertion over the given challenge.
+     *
+     * @param request the challenge, application and credential to sign with
+     * @return the authenticator's response (signature, flags and counter)
+     * @throws IOException if the authenticator could not be reached or declined to sign
+     */
+    SecurityKeySignatureData sign(SecurityKeySigningRequest request) throws IOException;
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/fido/SecurityKeySigningRequest.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/fido/SecurityKeySigningRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.fido;
+
+/**
+ * The inputs a {@link SecurityKeySigner} needs to make an authenticator produce an assertion.
+ * <p>
+ * In WebAuthn terms: {@link #getApplication() application} is the RP id, {@link #getChallenge()
+ * challenge} is the client-data hash, and {@link #getKeyHandle() keyHandle} identifies the
+ * credential to assert with.
+ */
+public class SecurityKeySigningRequest {
+
+    private final String keyTypeName;
+    private final String application;
+    private final byte[] keyHandle;
+    private final byte[] challenge;
+    private final byte minFlags;
+
+    public SecurityKeySigningRequest(String keyTypeName, String application, byte[] keyHandle, byte[] challenge, byte minFlags) {
+        this.keyTypeName = keyTypeName;
+        this.application = application;
+        this.keyHandle = keyHandle;
+        this.challenge = challenge;
+        this.minFlags = minFlags;
+    }
+
+    /** @return the SSH key type, e.g. {@code sk-ssh-ed25519@openssh.com}. */
+    public String getKeyTypeName() {
+        return keyTypeName;
+    }
+
+    /** @return the application string, e.g. {@code "ssh:"} (the WebAuthn RP id). */
+    public String getApplication() {
+        return application;
+    }
+
+    /** @return the credential / key handle stored in the private key file. */
+    public byte[] getKeyHandle() {
+        return keyHandle;
+    }
+
+    /** @return the SHA-256 of the SSH data to sign (the WebAuthn client-data hash). */
+    public byte[] getChallenge() {
+        return challenge;
+    }
+
+    /**
+     * @return the minimum authenticator flags requested by the key file: bit 0
+     * ({@code SSH_SK_USER_PRESENCE_REQD}) and bit 2 ({@code SSH_SK_USER_VERIFICATION_REQD}). An
+     * implementation should ask the authenticator for at least these.
+     */
+    public byte getMinFlags() {
+        return minFlags;
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
@@ -17,6 +17,9 @@ package com.hierynomus.sshj.userauth.keyprovider;
 
 import com.hierynomus.sshj.common.KeyAlgorithm;
 import com.hierynomus.sshj.common.KeyDecryptionFailedException;
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPrivateKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPublicKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySigner;
 import com.hierynomus.sshj.transport.cipher.BlockCiphers;
 import com.hierynomus.sshj.transport.cipher.ChachaPolyCiphers;
 import com.hierynomus.sshj.transport.cipher.GcmCiphers;
@@ -74,11 +77,23 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
     }
 
     private PublicKey pubKey;
+    private SecurityKeySigner securityKeySigner;
 
     @Override
     public PublicKey getPublic()
             throws IOException {
         return pubKey != null ? pubKey : super.getPublic();
+    }
+
+    /**
+     * Attach the bridge to the hardware authenticator used to sign with a FIDO/U2F security key
+     * ({@code sk-ecdsa-sha2-nistp256@openssh.com} / {@code sk-ssh-ed25519@openssh.com}). Without it
+     * such a key can be read but not used to sign. Not needed when authenticating via an SSH agent.
+     *
+     * @param securityKeySigner the signer, or {@code null} to clear it
+     */
+    public void setSecurityKeySigner(SecurityKeySigner securityKeySigner) {
+        this.securityKeySigner = securityKeySigner;
     }
 
     public static class Factory
@@ -371,6 +386,12 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
             case ECDSA521:
                 kp = new KeyPair(publicKey, createECDSAPrivateKey(kt, keyBuffer, ECDSACurve.SECP521R1));
                 break;
+            case SK_ED25519:
+                kp = readSecurityKey(kt, keyBuffer, publicKey, false);
+                break;
+            case SK_ECDSA:
+                kp = readSecurityKey(kt, keyBuffer, publicKey, true);
+                break;
 
             default:
                 throw new IOException("Cannot decode keytype " + keyType + " in openssh-key-v1 files (yet).");
@@ -384,6 +405,31 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
             }
         }
         return kp;
+    }
+
+    /**
+     * Read a FIDO/U2F security key private section, per OpenSSH {@code sshkey_private_deserialize}.
+     * There is no private scalar - only the application, authenticator flags and key handle. Signing
+     * is delegated to the configured {@link SecurityKeySigner}.
+     */
+    private KeyPair readSecurityKey(KeyType kt, PlainBuffer keyBuffer, PublicKey publicKey, boolean ecdsa) throws IOException {
+        if (ecdsa) {
+            keyBuffer.readString(); // curve name, e.g. "nistp256"
+            keyBuffer.readBytes();  // Q (the EC point)
+        } else {
+            keyBuffer.readBytes();  // enc_A (the Ed25519 public key)
+        }
+        keyBuffer.readString();     // application (also carried by the public key)
+        final byte flags = keyBuffer.readByte();
+        final byte[] keyHandle = keyBuffer.readBytes();
+        keyBuffer.readBytes();      // reserved
+
+        if (!(publicKey instanceof SecurityKeyPublicKey)) {
+            throw new IOException("Expected a security-key public key for " + kt + " but got: " + publicKey);
+        }
+        final SecurityKeyPrivateKey privateKey = new SecurityKeyPrivateKey(
+                kt.toString(), (SecurityKeyPublicKey) publicKey, flags, keyHandle, securityKeySigner);
+        return new KeyPair(publicKey, privateKey);
     }
 
     private PrivateKey createECDSAPrivateKey(KeyType kt, PlainBuffer buffer, ECDSACurve ecdsaCurve) throws GeneralSecurityException, Buffer.BufferException {

--- a/src/main/java/net/schmizz/sshj/DefaultConfig.java
+++ b/src/main/java/net/schmizz/sshj/DefaultConfig.java
@@ -135,6 +135,8 @@ public class DefaultConfig
         setKeyAlgorithms(Arrays.<Factory.Named<KeyAlgorithm>>asList(
                 KeyAlgorithms.EdDSA25519CertV01(),
                 KeyAlgorithms.EdDSA25519(),
+                KeyAlgorithms.SkSSHEd25519(),
+                KeyAlgorithms.SkECDSANistp256(),
                 KeyAlgorithms.ECDSASHANistp521CertV01(),
                 KeyAlgorithms.ECDSASHANistp521(),
                 KeyAlgorithms.ECDSASHANistp384CertV01(),

--- a/src/main/java/net/schmizz/sshj/common/KeyType.java
+++ b/src/main/java/net/schmizz/sshj/common/KeyType.java
@@ -18,6 +18,8 @@ package net.schmizz.sshj.common;
 import com.hierynomus.sshj.common.KeyAlgorithm;
 import com.hierynomus.sshj.signature.SignatureEdDSA;
 import com.hierynomus.sshj.userauth.certificate.Certificate;
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPrivateKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPublicKey;
 import net.schmizz.sshj.common.Buffer.BufferException;
 import net.schmizz.sshj.signature.Signature;
 import net.schmizz.sshj.signature.SignatureDSA;
@@ -200,7 +202,84 @@ public enum KeyType {
 
         @Override
         protected boolean isMyType(Key key) {
+            // A FIDO/U2F (sk-ssh-ed25519) key wraps an Ed25519 key but is a distinct type.
+            if (key instanceof SecurityKeyPublicKey || key instanceof SecurityKeyPrivateKey) {
+                return false;
+            }
             return "EdDSA".equals(key.getAlgorithm()) || "Ed25519".equals(key.getAlgorithm());
+        }
+    },
+
+    /** OpenSSH FIDO/U2F security key backed by ECDSA NIST P-256 */
+    SK_ECDSA("sk-ecdsa-sha2-nistp256@openssh.com") {
+        @Override
+        public PublicKey readPubKeyFromBuffer(Buffer<?> buf) throws GeneralSecurityException {
+            final PublicKey delegate = ECDSAVariationsAdapter.readPubKeyFromBuffer(buf, "256");
+            try {
+                final String application = buf.readString();
+                return new SecurityKeyPublicKey(delegate, application);
+            } catch (Buffer.BufferException be) {
+                throw new GeneralSecurityException(be);
+            }
+        }
+
+        @Override
+        protected void writePubKeyContentsIntoBuffer(PublicKey pk, Buffer<?> buf) {
+            final SecurityKeyPublicKey sk = (SecurityKeyPublicKey) pk;
+            ECDSAVariationsAdapter.writePubKeyContentsIntoBuffer(sk.getDelegate(), buf);
+            buf.putString(sk.getApplication());
+        }
+
+        @Override
+        protected boolean isMyType(Key key) {
+            if (key instanceof SecurityKeyPublicKey) {
+                return ECDSAVariationsAdapter.isECKeyWithFieldSize(((SecurityKeyPublicKey) key).getDelegate(), 256);
+            }
+            if (key instanceof SecurityKeyPrivateKey) {
+                return sType.equals(((SecurityKeyPrivateKey) key).getKeyTypeName());
+            }
+            return false;
+        }
+    },
+
+    /** OpenSSH FIDO/U2F security key backed by Ed25519 */
+    SK_ED25519("sk-ssh-ed25519@openssh.com") {
+        @Override
+        public PublicKey readPubKeyFromBuffer(Buffer<?> buf) throws GeneralSecurityException {
+            try {
+                final int keyLen = buf.readUInt32AsInt();
+                final byte[] publicKeyBinary = new byte[keyLen];
+                buf.readRawBytes(publicKeyBinary);
+                final PublicKey delegate = Ed25519KeyFactory.getPublicKey(publicKeyBinary);
+                final String application = buf.readString();
+                return new SecurityKeyPublicKey(delegate, application);
+            } catch (Buffer.BufferException be) {
+                throw new GeneralSecurityException(be);
+            }
+        }
+
+        @Override
+        protected void writePubKeyContentsIntoBuffer(PublicKey pk, Buffer<?> buf) {
+            final SecurityKeyPublicKey sk = (SecurityKeyPublicKey) pk;
+            final byte[] encoded = sk.getDelegate().getEncoded();
+            final int keyLength = 32;
+            final int headerLength = encoded.length - keyLength;
+            final byte[] encodedPublicKey = new byte[keyLength];
+            System.arraycopy(encoded, headerLength, encodedPublicKey, 0, keyLength);
+            buf.putBytes(encodedPublicKey);
+            buf.putString(sk.getApplication());
+        }
+
+        @Override
+        protected boolean isMyType(Key key) {
+            if (key instanceof SecurityKeyPublicKey) {
+                final String algorithm = ((SecurityKeyPublicKey) key).getDelegate().getAlgorithm();
+                return "EdDSA".equals(algorithm) || "Ed25519".equals(algorithm);
+            }
+            if (key instanceof SecurityKeyPrivateKey) {
+                return sType.equals(((SecurityKeyPrivateKey) key).getKeyTypeName());
+            }
+            return false;
         }
     },
 

--- a/src/main/java/net/schmizz/sshj/userauth/method/KeyedAuthMethod.java
+++ b/src/main/java/net/schmizz/sshj/userauth/method/KeyedAuthMethod.java
@@ -16,6 +16,7 @@
 package net.schmizz.sshj.userauth.method;
 
 import com.hierynomus.sshj.key.KeyAlgorithm;
+import com.hierynomus.sshj.signature.AbstractSecurityKeySignature;
 import net.schmizz.sshj.common.Buffer;
 import net.schmizz.sshj.common.KeyType;
 import net.schmizz.sshj.common.SSHPacket;
@@ -34,14 +35,14 @@ public abstract class KeyedAuthMethod
         extends AbstractAuthMethod {
 
     protected final KeyProvider kProv;
-    private Queue<KeyAlgorithm> available;
+    protected Queue<KeyAlgorithm> available;
 
     public KeyedAuthMethod(String name, KeyProvider kProv) {
         super(name);
         this.kProv = kProv;
     }
 
-    private KeyAlgorithm getPublicKeyAlgorithm(KeyType keyType) throws TransportException {
+    protected KeyAlgorithm getPublicKeyAlgorithm(KeyType keyType) throws TransportException {
         if (available == null) {
             available = new LinkedList<>(params.getTransport().getClientKeyAlgorithms(keyType));
         }
@@ -103,7 +104,13 @@ public abstract class KeyedAuthMethod
                 .putString(params.getTransport().getSessionID())
                 .putBuffer(reqBuf) // & rest of the data for sig
                 .getCompactData());
-        reqBuf.putSignature(signature.getSignatureName(), signature.encode(signature.sign()));
+        final byte[] encoded = signature.encode(signature.sign());
+        if (signature instanceof AbstractSecurityKeySignature) {
+            // A FIDO/U2F signature already encodes the type, flags and counter; write it as one string.
+            reqBuf.putString(encoded);
+        } else {
+            reqBuf.putSignature(signature.getSignatureName(), encoded);
+        }
         return reqBuf;
     }
 

--- a/src/test/java/com/hierynomus/sshj/signature/SecurityKeyMinaInteropTest.java
+++ b/src/test/java/com/hierynomus/sshj/signature/SecurityKeyMinaInteropTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.signature;
+
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPrivateKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPublicKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySignatureData;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySigner;
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.KeyType;
+import net.schmizz.sshj.signature.Signature;
+import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.spec.ECGenParameterSpec;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Interoperability check: a FIDO/U2F (sk-*) signature produced by sshj is verified by Apache MINA
+ * sshd's independent implementation, and MINA also parses sshj's public-key blob. This pins both the
+ * public-key encoding and the signature format to a second implementation, not just sshj's own.
+ */
+public class SecurityKeyMinaInteropTest {
+
+    private static final String APPLICATION = "ssh:";
+    private static final byte FLAGS = 0x01; // user-present
+    private static final long COUNTER = 42L;
+
+    @Test
+    public void minaVerifiesOurSkEd25519Signature() throws Exception {
+        KeyPair kp = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        byte[] message = "interop ed25519".getBytes(StandardCharsets.UTF_8);
+
+        SecurityKeyPublicKey ourPublicKey = new SecurityKeyPublicKey(kp.getPublic(), APPLICATION);
+        byte[] ourSignature = sign(new SignatureSkEd25519(), KeyType.SK_ED25519, ourPublicKey, kp.getPrivate(), "Ed25519", message);
+        byte[] ourPublicKeyBlob = new Buffer.PlainBuffer().putPublicKey(ourPublicKey).getCompactData();
+
+        java.security.PublicKey minaKey = new ByteArrayBuffer(ourPublicKeyBlob).getRawPublicKey();
+        org.apache.sshd.common.signature.Signature minaVerifier = new org.apache.sshd.common.signature.SignatureSkED25519();
+        minaVerifier.initVerifier(null, minaKey);
+        minaVerifier.update(null, message);
+        assertTrue(minaVerifier.verify(null, ourSignature), "MINA should verify sshj's sk-ssh-ed25519 signature");
+    }
+
+    @Test
+    public void minaVerifiesOurSkEcdsaSignature() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyPair kp = kpg.generateKeyPair();
+        byte[] message = "interop ecdsa".getBytes(StandardCharsets.UTF_8);
+
+        SecurityKeyPublicKey ourPublicKey = new SecurityKeyPublicKey(kp.getPublic(), APPLICATION);
+        byte[] ourSignature = sign(new SignatureSkEcdsa(), KeyType.SK_ECDSA, ourPublicKey, kp.getPrivate(), "SHA256withECDSA", message);
+        byte[] ourPublicKeyBlob = new Buffer.PlainBuffer().putPublicKey(ourPublicKey).getCompactData();
+
+        java.security.PublicKey minaKey = new ByteArrayBuffer(ourPublicKeyBlob).getRawPublicKey();
+        org.apache.sshd.common.signature.Signature minaVerifier = new org.apache.sshd.common.signature.SignatureSkECDSA();
+        minaVerifier.initVerifier(null, minaKey);
+        minaVerifier.update(null, message);
+        assertTrue(minaVerifier.verify(null, ourSignature), "MINA should verify sshj's sk-ecdsa signature");
+    }
+
+    /** Produce an sk signature through sshj's signing path, with a software authenticator standing in for hardware. */
+    private static byte[] sign(Signature signature, KeyType keyType, SecurityKeyPublicKey publicKey,
+                               PrivateKey credentialKey, String jcaAlgorithm, byte[] message) {
+        SecurityKeySigner signer = request -> {
+            byte[] authenticatorData = authenticatorData(request.getApplication(), FLAGS, COUNTER);
+            byte[] signed = concat(authenticatorData, request.getChallenge());
+            byte[] deviceSig = jcaSign(credentialKey, jcaAlgorithm, signed);
+            return new SecurityKeySignatureData(FLAGS, COUNTER, deviceSig);
+        };
+        SecurityKeyPrivateKey privateKey = new SecurityKeyPrivateKey(keyType.toString(), publicKey, FLAGS, new byte[]{7, 7}, signer);
+        signature.initSign(privateKey);
+        signature.update(message);
+        return signature.encode(signature.sign());
+    }
+
+    private static byte[] authenticatorData(String application, byte flags, long counter) {
+        byte[] rpIdHash = sha256(application.getBytes(StandardCharsets.UTF_8));
+        byte[] out = new byte[rpIdHash.length + 5];
+        System.arraycopy(rpIdHash, 0, out, 0, rpIdHash.length);
+        out[rpIdHash.length] = flags;
+        out[rpIdHash.length + 1] = (byte) ((counter >>> 24) & 0xff);
+        out[rpIdHash.length + 2] = (byte) ((counter >>> 16) & 0xff);
+        out[rpIdHash.length + 3] = (byte) ((counter >>> 8) & 0xff);
+        out[rpIdHash.length + 4] = (byte) (counter & 0xff);
+        return out;
+    }
+
+    private static byte[] jcaSign(PrivateKey key, String algorithm, byte[] data) {
+        try {
+            java.security.Signature s = java.security.Signature.getInstance(algorithm);
+            s.initSign(key);
+            s.update(data);
+            return s.sign();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] sha256(byte[] data) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(data);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
+    }
+}

--- a/src/test/java/com/hierynomus/sshj/signature/SecurityKeySignatureTest.java
+++ b/src/test/java/com/hierynomus/sshj/signature/SecurityKeySignatureTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.signature;
+
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPrivateKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPublicKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySignatureData;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySigner;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySigningRequest;
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.KeyType;
+import net.schmizz.sshj.signature.Signature;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.spec.ECGenParameterSpec;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates FIDO/U2F (sk-*) signature handling without any hardware, by synthesising an
+ * authenticator in software: the test holds the credential private key, builds the signed blob
+ * (SHA256(application) || flags || counter || SHA256(message)) by hand per PROTOCOL.u2f, and checks
+ * both verification and the signing path against it.
+ */
+public class SecurityKeySignatureTest {
+
+    private static final String APPLICATION = "ssh:";
+    private static final byte FLAGS = 0x05; // user-present + user-verified
+    private static final long COUNTER = 0x01020304L;
+
+    @Test
+    public void skEcdsaVerifies() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyPair kp = kpg.generateKeyPair();
+        byte[] message = "the ssh data to be signed".getBytes(StandardCharsets.UTF_8);
+
+        byte[] wireSig = synthesizeEcdsaSignature(kp.getPrivate(), message, FLAGS, COUNTER);
+
+        Signature sig = new SignatureSkEcdsa();
+        sig.initVerify(new SecurityKeyPublicKey(kp.getPublic(), APPLICATION));
+        sig.update(message);
+        assertTrue(sig.verify(wireSig), "sk-ecdsa signature should verify");
+    }
+
+    @Test
+    public void skEd25519Verifies() throws Exception {
+        KeyPair kp = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        byte[] message = "the ssh data to be signed".getBytes(StandardCharsets.UTF_8);
+
+        byte[] wireSig = synthesizeEd25519Signature(kp.getPrivate(), message, FLAGS, COUNTER);
+
+        Signature sig = new SignatureSkEd25519();
+        sig.initVerify(new SecurityKeyPublicKey(kp.getPublic(), APPLICATION));
+        sig.update(message);
+        assertTrue(sig.verify(wireSig), "sk-ssh-ed25519 signature should verify");
+    }
+
+    @Test
+    public void tamperedMessageFailsVerification() throws Exception {
+        KeyPair kp = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        byte[] message = "original".getBytes(StandardCharsets.UTF_8);
+        byte[] wireSig = synthesizeEd25519Signature(kp.getPrivate(), message, FLAGS, COUNTER);
+
+        Signature sig = new SignatureSkEd25519();
+        sig.initVerify(new SecurityKeyPublicKey(kp.getPublic(), APPLICATION));
+        sig.update("tampered".getBytes(StandardCharsets.UTF_8));
+        assertFalse(sig.verify(wireSig), "verification must fail when the signed message differs");
+    }
+
+    @Test
+    public void tamperedCounterFailsVerification() throws Exception {
+        KeyPair kp = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        byte[] message = "msg".getBytes(StandardCharsets.UTF_8);
+        // The signature was made over COUNTER, but the wire claims COUNTER+1 -> must fail.
+        byte[] inner = ed25519Inner(kp.getPrivate(), message, FLAGS, COUNTER);
+        byte[] wireSig = new Buffer.PlainBuffer()
+                .putString(KeyType.SK_ED25519.toString())
+                .putBytes(inner)
+                .putByte(FLAGS)
+                .putUInt32(COUNTER + 1)
+                .getCompactData();
+
+        Signature sig = new SignatureSkEd25519();
+        sig.initVerify(new SecurityKeyPublicKey(kp.getPublic(), APPLICATION));
+        sig.update(message);
+        assertFalse(sig.verify(wireSig), "verification must fail when the counter is altered");
+    }
+
+    /** Drives the full signing path (SecurityKeySigner -> Signature#sign/#encode) and verifies the result. */
+    @Test
+    public void skEcdsaSignThenVerifyRoundTrips() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyPair kp = kpg.generateKeyPair();
+        byte[] message = "round trip".getBytes(StandardCharsets.UTF_8);
+
+        SecurityKeyPublicKey pub = new SecurityKeyPublicKey(kp.getPublic(), APPLICATION);
+        SecurityKeySigner signer = softwareAuthenticator(kp.getPrivate(), "SHA256withECDSA", FLAGS, COUNTER);
+        SecurityKeyPrivateKey priv = new SecurityKeyPrivateKey(KeyType.SK_ECDSA.toString(), pub, FLAGS, new byte[]{1, 2, 3}, signer);
+
+        Signature signing = new SignatureSkEcdsa();
+        signing.initSign(priv);
+        signing.update(message);
+        byte[] wireSig = signing.encode(signing.sign());
+
+        Signature verifying = new SignatureSkEcdsa();
+        verifying.initVerify(pub);
+        verifying.update(message);
+        assertTrue(verifying.verify(wireSig), "signed sk-ecdsa value should verify");
+    }
+
+    @Test
+    public void skEd25519SignThenVerifyRoundTrips() throws Exception {
+        KeyPair kp = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        byte[] message = "round trip".getBytes(StandardCharsets.UTF_8);
+
+        SecurityKeyPublicKey pub = new SecurityKeyPublicKey(kp.getPublic(), APPLICATION);
+        SecurityKeySigner signer = softwareAuthenticator(kp.getPrivate(), "Ed25519", FLAGS, COUNTER);
+        SecurityKeyPrivateKey priv = new SecurityKeyPrivateKey(KeyType.SK_ED25519.toString(), pub, FLAGS, new byte[]{9}, signer);
+
+        Signature signing = new SignatureSkEd25519();
+        signing.initSign(priv);
+        signing.update(message);
+        byte[] wireSig = signing.encode(signing.sign());
+
+        Signature verifying = new SignatureSkEd25519();
+        verifying.initVerify(pub);
+        verifying.update(message);
+        assertTrue(verifying.verify(wireSig), "signed sk-ssh-ed25519 value should verify");
+
+        // The encoded wire signature must carry the flags and counter the authenticator reported.
+        Buffer.PlainBuffer buf = new Buffer.PlainBuffer(wireSig);
+        assertArrayEquals(KeyType.SK_ED25519.toString().getBytes(StandardCharsets.UTF_8), buf.readBytes());
+        buf.readBytes(); // raw signature
+        org.junit.jupiter.api.Assertions.assertEquals(FLAGS, buf.readByte());
+        org.junit.jupiter.api.Assertions.assertEquals(COUNTER, buf.readUInt32());
+    }
+
+    // --- software authenticator helpers (these stand in for the YubiKey) ---
+
+    /**
+     * A {@link SecurityKeySigner} that signs in software, exactly as a real authenticator would:
+     * it rebuilds the authenticator data and signs authenticatorData || clientDataHash.
+     */
+    private static SecurityKeySigner softwareAuthenticator(PrivateKey credentialKey, String jcaAlgorithm, byte flags, long counter) {
+        return request -> {
+            byte[] signedData = concat(authenticatorData(request.getApplication(), flags, counter), request.getChallenge());
+            byte[] deviceSig = jcaSign(credentialKey, jcaAlgorithm, signedData);
+            return new SecurityKeySignatureData(flags, counter, deviceSig);
+        };
+    }
+
+    private static byte[] synthesizeEcdsaSignature(PrivateKey credentialKey, byte[] message, byte flags, long counter) throws Exception {
+        byte[] signedData = concat(authenticatorData(APPLICATION, flags, counter), sha256(message));
+        byte[] der = jcaSign(credentialKey, "SHA256withECDSA", signedData);
+        byte[] inner = derToSshEcdsa(der);
+        return new Buffer.PlainBuffer()
+                .putString(KeyType.SK_ECDSA.toString())
+                .putBytes(inner)
+                .putByte(flags)
+                .putUInt32(counter)
+                .getCompactData();
+    }
+
+    private static byte[] synthesizeEd25519Signature(PrivateKey credentialKey, byte[] message, byte flags, long counter) throws Exception {
+        byte[] inner = ed25519Inner(credentialKey, message, flags, counter);
+        return new Buffer.PlainBuffer()
+                .putString(KeyType.SK_ED25519.toString())
+                .putBytes(inner)
+                .putByte(flags)
+                .putUInt32(counter)
+                .getCompactData();
+    }
+
+    private static byte[] ed25519Inner(PrivateKey credentialKey, byte[] message, byte flags, long counter) throws Exception {
+        byte[] signedData = concat(authenticatorData(APPLICATION, flags, counter), sha256(message));
+        return jcaSign(credentialKey, "Ed25519", signedData);
+    }
+
+    /** authenticatorData = SHA256(application) || flags || counter (4 bytes big-endian). Built by hand. */
+    private static byte[] authenticatorData(String application, byte flags, long counter) {
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            out.write(sha256(application.getBytes(StandardCharsets.UTF_8)));
+            out.write(flags);
+            out.write((int) ((counter >>> 24) & 0xff));
+            out.write((int) ((counter >>> 16) & 0xff));
+            out.write((int) ((counter >>> 8) & 0xff));
+            out.write((int) (counter & 0xff));
+            return out.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] derToSshEcdsa(byte[] der) throws Exception {
+        com.hierynomus.asn1.ASN1InputStream in = new com.hierynomus.asn1.ASN1InputStream(
+                new com.hierynomus.asn1.encodingrules.der.DERDecoder(), new java.io.ByteArrayInputStream(der));
+        com.hierynomus.asn1.types.constructed.ASN1Sequence seq = in.readObject();
+        java.math.BigInteger r = ((com.hierynomus.asn1.types.primitive.ASN1Integer) seq.get(0)).getValue();
+        java.math.BigInteger s = ((com.hierynomus.asn1.types.primitive.ASN1Integer) seq.get(1)).getValue();
+        return new Buffer.PlainBuffer().putMPInt(r).putMPInt(s).getCompactData();
+    }
+
+    private static byte[] jcaSign(PrivateKey key, String algorithm, byte[] data) {
+        try {
+            java.security.Signature s = java.security.Signature.getInstance(algorithm);
+            s.initSign(key);
+            s.update(data);
+            return s.sign();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] sha256(byte[] data) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(data);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
+    }
+}

--- a/src/test/java/com/hierynomus/sshj/userauth/agent/AgentProxyLiveTest.java
+++ b/src/test/java/com/hierynomus/sshj/userauth/agent/AgentProxyLiveTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import com.hierynomus.sshj.key.KeyAlgorithm;
+import net.schmizz.sshj.DefaultConfig;
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.Factory;
+import net.schmizz.sshj.signature.Signature;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end test against a real, running ssh-agent over a unix-domain socket. It exercises the
+ * reflective {@link UnixSocketAgentConnection}, identity listing and the sign request, then verifies
+ * the agent's signature with sshj's own signature machinery.
+ * <p>
+ * Opt-in: it only runs when {@code SSHJ_TEST_AGENT_SOCK} points at an agent socket that holds at
+ * least one key, so ordinary CI is unaffected. See {@code AgentLiveTest} orchestration in the PR
+ * notes for how to drive it. Requires a Java 16+ runtime for unix-domain sockets.
+ */
+@EnabledIfEnvironmentVariable(named = "SSHJ_TEST_AGENT_SOCK", matches = ".+")
+public class AgentProxyLiveTest {
+
+    @Test
+    public void listsIdentitiesAndProducesVerifiableSignatures() throws Exception {
+        String socketPath = System.getenv("SSHJ_TEST_AGENT_SOCK");
+        try (AgentProxy agent = new AgentProxy(new UnixSocketAgentConnection(socketPath))) {
+            List<AgentIdentity> identities = agent.getIdentities();
+            assertFalse(identities.isEmpty(), "the test agent should hold at least one identity");
+
+            byte[] data = "sshj agent live test challenge".getBytes(StandardCharsets.UTF_8);
+            for (AgentIdentity identity : identities) {
+                byte[] signature = agent.sign(identity.getKeyBlob(), data, 0);
+
+                String signatureType = new Buffer.PlainBuffer(signature).readString();
+                Signature verifier = signatureForType(signatureType);
+                verifier.initVerify(identity.getPublicKey());
+                verifier.update(data);
+                assertTrue(verifier.verify(signature),
+                        "agent signature should verify for " + identity + " (" + signatureType + ")");
+            }
+        }
+    }
+
+    private static Signature signatureForType(String signatureName) {
+        for (Factory.Named<KeyAlgorithm> factory : new DefaultConfig().getKeyAlgorithms()) {
+            Signature signature = factory.create().newSignature();
+            if (signature.getSignatureName().equals(signatureName)) {
+                return signature;
+            }
+        }
+        throw new IllegalStateException("No registered Signature for agent signature type: " + signatureName);
+    }
+}

--- a/src/test/java/com/hierynomus/sshj/userauth/agent/AuthAgentTest.java
+++ b/src/test/java/com/hierynomus/sshj/userauth/agent/AuthAgentTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import com.hierynomus.sshj.test.SshServerExtension;
+import net.schmizz.sshj.SSHClient;
+import org.apache.sshd.server.auth.pubkey.AcceptAllPublickeyAuthenticator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Authenticates to a real (in-process Apache MINA) SSH server via {@link AuthAgent}, with signing
+ * delegated to an in-memory {@link FakeSshAgent}. This proves the full agent auth flow: the agent
+ * lists the identity, the server sends PK_OK, the agent signs the userauth blob, and the server
+ * verifies the signature. (A FIDO security key authenticates by exactly this path, with a YubiKey
+ * standing in for the fake agent.)
+ */
+public class AuthAgentTest {
+
+    @RegisterExtension
+    public SshServerExtension fixture = new SshServerExtension(false);
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        fixture.getServer().setPublickeyAuthenticator(AcceptAllPublickeyAuthenticator.INSTANCE);
+        fixture.getServer().start();
+    }
+
+    @Test
+    public void authenticatesWithEd25519AgentKey() throws Exception {
+        authenticatesWith(KeyPairGenerator.getInstance("Ed25519").generateKeyPair(), "ed25519-agent-key");
+    }
+
+    @Test
+    public void authenticatesWithEcdsaAgentKey() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(new java.security.spec.ECGenParameterSpec("secp256r1"));
+        authenticatesWith(kpg.generateKeyPair(), "ecdsa-agent-key");
+    }
+
+    private void authenticatesWith(KeyPair keyPair, String comment) throws Exception {
+        try (FakeSshAgent fakeAgent = new FakeSshAgent()
+                .addIdentity(keyPair.getPublic(), keyPair.getPrivate(), comment)
+                .start()) {
+            AgentProxy agent = new AgentProxy(fakeAgent.connection());
+
+            List<AgentIdentity> identities = agent.getIdentities();
+            assertEquals(1, identities.size());
+            assertEquals(comment, identities.get(0).getComment());
+
+            SSHClient client = fixture.setupConnectedDefaultClient();
+            client.auth("jeroen", new AuthAgent(agent, identities.get(0)));
+            assertTrue(client.isAuthenticated(), "client should authenticate via the agent");
+        }
+    }
+}

--- a/src/test/java/com/hierynomus/sshj/userauth/agent/FakeSshAgent.java
+++ b/src/test/java/com/hierynomus/sshj/userauth/agent/FakeSshAgent.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.KeyType;
+import net.schmizz.sshj.signature.Signature;
+
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A minimal in-memory SSH agent for tests: it speaks the agent wire protocol over loopback pipes and
+ * signs with software keys. This lets the agent auth path be tested end-to-end against a real SSH
+ * server without any external agent process or hardware.
+ */
+class FakeSshAgent implements Closeable {
+
+    private static final byte SSH_AGENT_FAILURE = 5;
+    private static final byte SSH_AGENTC_REQUEST_IDENTITIES = 11;
+    private static final byte SSH_AGENT_IDENTITIES_ANSWER = 12;
+    private static final byte SSH_AGENTC_SIGN_REQUEST = 13;
+    private static final byte SSH_AGENT_SIGN_RESPONSE = 14;
+
+    private static final class Identity {
+        final byte[] keyBlob;
+        final String comment;
+        final PrivateKey privateKey;
+        final Signature signature;
+
+        Identity(byte[] keyBlob, String comment, PrivateKey privateKey, Signature signature) {
+            this.keyBlob = keyBlob;
+            this.comment = comment;
+            this.privateKey = privateKey;
+            this.signature = signature;
+        }
+    }
+
+    private final List<Identity> identities = new ArrayList<>();
+    private final DataInputStream agentIn;
+    private final OutputStream agentOut;
+    private final InputStream clientIn;
+    private final OutputStream clientOut;
+    private final Thread thread;
+
+    FakeSshAgent() throws IOException {
+        PipedInputStream clientToAgent = new PipedInputStream(1 << 16);
+        PipedOutputStream clientWrites = new PipedOutputStream(clientToAgent);
+        PipedInputStream agentToClient = new PipedInputStream(1 << 16);
+        PipedOutputStream agentWrites = new PipedOutputStream(agentToClient);
+
+        this.agentIn = new DataInputStream(clientToAgent);
+        this.agentOut = agentWrites;
+        this.clientIn = agentToClient;
+        this.clientOut = clientWrites;
+
+        this.thread = new Thread(this::serve, "fake-ssh-agent");
+        this.thread.setDaemon(true);
+    }
+
+    FakeSshAgent addIdentity(PublicKey publicKey, PrivateKey privateKey, String comment) {
+        byte[] keyBlob = new Buffer.PlainBuffer().putPublicKey(publicKey).getCompactData();
+        Signature signature = signatureFor(KeyType.fromKey(publicKey));
+        identities.add(new Identity(keyBlob, comment, privateKey, signature));
+        return this;
+    }
+
+    FakeSshAgent start() {
+        thread.start();
+        return this;
+    }
+
+    AgentConnection connection() {
+        return new AgentConnection() {
+            @Override
+            public InputStream getInputStream() {
+                return clientIn;
+            }
+
+            @Override
+            public OutputStream getOutputStream() {
+                return clientOut;
+            }
+
+            @Override
+            public void close() {
+                // The proxy closing its side ends the serve loop via EOF.
+            }
+        };
+    }
+
+    private void serve() {
+        try {
+            while (true) {
+                int length = agentIn.readInt();
+                byte type = agentIn.readByte();
+                byte[] contents = new byte[length - 1];
+                agentIn.readFully(contents);
+                handle(type, contents);
+            }
+        } catch (IOException eof) {
+            // pipe closed -> stop
+        }
+    }
+
+    private void handle(byte type, byte[] contents) throws IOException {
+        switch (type) {
+            case SSH_AGENTC_REQUEST_IDENTITIES:
+                Buffer.PlainBuffer answer = new Buffer.PlainBuffer().putUInt32(identities.size());
+                for (Identity identity : identities) {
+                    answer.putBytes(identity.keyBlob).putString(identity.comment);
+                }
+                writeMessage(SSH_AGENT_IDENTITIES_ANSWER, answer.getCompactData());
+                break;
+            case SSH_AGENTC_SIGN_REQUEST:
+                signRequest(contents);
+                break;
+            default:
+                writeMessage(SSH_AGENT_FAILURE, new byte[0]);
+        }
+    }
+
+    private void signRequest(byte[] contents) throws IOException {
+        try {
+            Buffer.PlainBuffer request = new Buffer.PlainBuffer(contents);
+            byte[] keyBlob = request.readBytes();
+            byte[] data = request.readBytes();
+            request.readUInt32(); // flags, ignored by this fake (no RSA-SHA2)
+
+            Identity identity = findIdentity(keyBlob);
+            if (identity == null) {
+                writeMessage(SSH_AGENT_FAILURE, new byte[0]);
+                return;
+            }
+            identity.signature.initSign(identity.privateKey);
+            identity.signature.update(data);
+            byte[] signatureValue = new Buffer.PlainBuffer()
+                    .putString(identity.signature.getSignatureName())
+                    .putBytes(identity.signature.encode(identity.signature.sign()))
+                    .getCompactData();
+            writeMessage(SSH_AGENT_SIGN_RESPONSE, new Buffer.PlainBuffer().putBytes(signatureValue).getCompactData());
+        } catch (Buffer.BufferException e) {
+            writeMessage(SSH_AGENT_FAILURE, new byte[0]);
+        }
+    }
+
+    private Identity findIdentity(byte[] keyBlob) {
+        for (Identity identity : identities) {
+            if (java.util.Arrays.equals(identity.keyBlob, keyBlob)) {
+                return identity;
+            }
+        }
+        return null;
+    }
+
+    private void writeMessage(byte type, byte[] contents) throws IOException {
+        int length = 1 + contents.length;
+        agentOut.write(new byte[]{
+                (byte) (length >>> 24), (byte) (length >>> 16), (byte) (length >>> 8), (byte) length, type
+        });
+        agentOut.write(contents);
+        agentOut.flush();
+    }
+
+    private static Signature signatureFor(KeyType keyType) {
+        for (net.schmizz.sshj.common.Factory.Named<com.hierynomus.sshj.key.KeyAlgorithm> factory : new net.schmizz.sshj.DefaultConfig().getKeyAlgorithms()) {
+            com.hierynomus.sshj.key.KeyAlgorithm keyAlgorithm = factory.create();
+            if (keyAlgorithm.getKeyFormat() == keyType) {
+                return keyAlgorithm.newSignature();
+            }
+        }
+        throw new IllegalArgumentException("No signature available for key type " + keyType);
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            clientIn.close();
+            clientOut.close();
+            agentOut.close();
+            agentIn.close();
+        } finally {
+            thread.interrupt();
+        }
+    }
+}

--- a/src/test/java/com/hierynomus/sshj/userauth/fido/SecurityKeyPublicKeyTest.java
+++ b/src/test/java/com/hierynomus/sshj/userauth/fido/SecurityKeyPublicKeyTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.fido;
+
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.KeyType;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Verifies that the {@code sk-ecdsa-sha2-nistp256@openssh.com} and {@code sk-ssh-ed25519@openssh.com}
+ * public key blobs are written and read back exactly per OpenSSH PROTOCOL.u2f.
+ */
+public class SecurityKeyPublicKeyTest {
+
+    private static final String APPLICATION = "ssh:";
+
+    @Test
+    public void skEcdsaIsRecognizedByType() {
+        assertEquals(KeyType.SK_ECDSA, KeyType.fromString("sk-ecdsa-sha2-nistp256@openssh.com"));
+        assertEquals(KeyType.SK_ED25519, KeyType.fromString("sk-ssh-ed25519@openssh.com"));
+    }
+
+    @Test
+    public void skEcdsaRoundTrips() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyPair kp = kpg.generateKeyPair();
+
+        SecurityKeyPublicKey key = new SecurityKeyPublicKey(kp.getPublic(), APPLICATION);
+        assertEquals(KeyType.SK_ECDSA, KeyType.fromKey(key));
+
+        byte[] blob = new Buffer.PlainBuffer().putPublicKey(key).getCompactData();
+
+        // Structure per PROTOCOL.u2f: string type, string curve, string Q, string application
+        Buffer.PlainBuffer reader = new Buffer.PlainBuffer(blob);
+        assertEquals("sk-ecdsa-sha2-nistp256@openssh.com", reader.readString());
+        assertEquals("nistp256", reader.readString());
+        reader.readBytes(); // Q
+        assertEquals(APPLICATION, reader.readString());
+
+        // Round trip
+        PublicKey parsed = new Buffer.PlainBuffer(blob).readPublicKey();
+        SecurityKeyPublicKey parsedSk = assertInstanceOf(SecurityKeyPublicKey.class, parsed);
+        assertEquals(APPLICATION, parsedSk.getApplication());
+        assertEquals(KeyType.SK_ECDSA, KeyType.fromKey(parsed));
+        assertArrayEquals(blob, new Buffer.PlainBuffer().putPublicKey(parsed).getCompactData());
+    }
+
+    @Test
+    public void skEd25519RoundTrips() throws Exception {
+        KeyPair kp = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+
+        SecurityKeyPublicKey key = new SecurityKeyPublicKey(kp.getPublic(), APPLICATION);
+        assertEquals(KeyType.SK_ED25519, KeyType.fromKey(key));
+
+        byte[] blob = new Buffer.PlainBuffer().putPublicKey(key).getCompactData();
+
+        // Structure per PROTOCOL.u2f: string type, string publicKey, string application
+        Buffer.PlainBuffer reader = new Buffer.PlainBuffer(blob);
+        assertEquals("sk-ssh-ed25519@openssh.com", reader.readString());
+        assertEquals(32, reader.readBytes().length); // raw Ed25519 public key
+        assertEquals(APPLICATION, reader.readString());
+
+        // Round trip
+        PublicKey parsed = new Buffer.PlainBuffer(blob).readPublicKey();
+        SecurityKeyPublicKey parsedSk = assertInstanceOf(SecurityKeyPublicKey.class, parsed);
+        assertEquals(APPLICATION, parsedSk.getApplication());
+        assertEquals(KeyType.SK_ED25519, KeyType.fromKey(parsed));
+        assertArrayEquals(blob, new Buffer.PlainBuffer().putPublicKey(parsed).getCompactData());
+    }
+
+    @Test
+    public void nonAsciiApplicationRoundTrips() throws Exception {
+        KeyPair kp = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        String application = "ssh:??-key"; // exercise UTF-8 length vs char count
+
+        SecurityKeyPublicKey key = new SecurityKeyPublicKey(kp.getPublic(), application);
+        byte[] blob = new Buffer.PlainBuffer().putPublicKey(key).getCompactData();
+        PublicKey parsed = new Buffer.PlainBuffer(blob).readPublicKey();
+
+        assertEquals(application, ((SecurityKeyPublicKey) parsed).getApplication());
+    }
+}

--- a/src/test/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1SecurityKeyTest.java
+++ b/src/test/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1SecurityKeyTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.keyprovider;
+
+import com.hierynomus.sshj.signature.SignatureSkEd25519;
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPrivateKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPublicKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySignatureData;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySigner;
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.KeyType;
+import net.schmizz.sshj.signature.Signature;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Loads a {@code sk-ssh-ed25519@openssh.com} key from a hand-built OpenSSH v1 key file (the
+ * authenticator-resident format: application, flags, key handle, no private scalar) and checks that
+ * the parsed key carries those fields and can sign once a {@link SecurityKeySigner} is attached.
+ */
+public class OpenSSHKeyV1SecurityKeyTest {
+
+    private static final String APPLICATION = "ssh:";
+    private static final byte FLAGS = 0x01;
+    private static final byte[] KEY_HANDLE = {10, 20, 30, 40, 50};
+
+    @Test
+    public void loadsSkEd25519PrivateKey() throws Exception {
+        KeyPair credential = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+        byte[] rawPublicKey = rawEd25519PublicKey(credential.getPublic());
+        String pem = buildOpenSshV1SkEd25519(rawPublicKey, APPLICATION, FLAGS, KEY_HANDLE, "sk-test@host");
+
+        OpenSSHKeyV1KeyFile keyFile = new OpenSSHKeyV1KeyFile();
+        keyFile.setSecurityKeySigner(softwareAuthenticator(credential.getPrivate()));
+        keyFile.init(new StringReader(pem), null, null);
+
+        PublicKey publicKey = keyFile.getPublic();
+        SecurityKeyPublicKey skPublic = assertInstanceOf(SecurityKeyPublicKey.class, publicKey);
+        assertEquals(APPLICATION, skPublic.getApplication());
+        assertEquals(KeyType.SK_ED25519, keyFile.getType());
+
+        PrivateKey privateKey = keyFile.getPrivate();
+        SecurityKeyPrivateKey skPrivate = assertInstanceOf(SecurityKeyPrivateKey.class, privateKey);
+        assertEquals(APPLICATION, skPrivate.getApplication());
+        assertEquals(FLAGS, skPrivate.getFlags());
+        assertArrayEquals(KEY_HANDLE, skPrivate.getKeyHandle());
+
+        // The loaded key can sign, and the signature verifies against the public key.
+        byte[] message = "loaded from openssh-key-v1".getBytes(StandardCharsets.UTF_8);
+        Signature signing = new SignatureSkEd25519();
+        signing.initSign(privateKey);
+        signing.update(message);
+        byte[] wireSignature = signing.encode(signing.sign());
+
+        Signature verifying = new SignatureSkEd25519();
+        verifying.initVerify(publicKey);
+        verifying.update(message);
+        assertTrue(verifying.verify(wireSignature), "signature from the loaded sk key should verify");
+    }
+
+    private static byte[] rawEd25519PublicKey(PublicKey publicKey) {
+        byte[] encoded = publicKey.getEncoded();
+        byte[] raw = new byte[32];
+        System.arraycopy(encoded, encoded.length - 32, raw, 0, 32);
+        return raw;
+    }
+
+    private static String buildOpenSshV1SkEd25519(byte[] rawPublicKey, String application, byte flags, byte[] keyHandle, String comment) {
+        byte[] publicKeyBlob = new Buffer.PlainBuffer()
+                .putString(KeyType.SK_ED25519.toString())
+                .putBytes(rawPublicKey)
+                .putString(application)
+                .getCompactData();
+
+        Buffer.PlainBuffer privateSection = new Buffer.PlainBuffer()
+                .putUInt32(0x01020304L) // checkint1
+                .putUInt32(0x01020304L) // checkint2
+                .putString(KeyType.SK_ED25519.toString())
+                .putBytes(rawPublicKey)
+                .putString(application)
+                .putByte(flags)
+                .putBytes(keyHandle)
+                .putString("") // reserved
+                .putString(comment);
+        // pad to the "none" cipher block size of 8 with 1, 2, 3, ...
+        byte pad = 1;
+        while (privateSection.available() % 8 != 0) {
+            privateSection.putByte(pad++);
+        }
+
+        byte[] blob = new Buffer.PlainBuffer()
+                .putRawBytes("openssh-key-v1\0".getBytes(StandardCharsets.UTF_8))
+                .putString("none") // cipher
+                .putString("none") // kdf
+                .putString("")     // kdf options
+                .putUInt32(1L)     // number of keys
+                .putString(publicKeyBlob)
+                .putString(privateSection.getCompactData())
+                .getCompactData();
+
+        return "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+                + Base64.getEncoder().encodeToString(blob) + "\n"
+                + "-----END OPENSSH PRIVATE KEY-----\n";
+    }
+
+    private static SecurityKeySigner softwareAuthenticator(PrivateKey credentialKey) {
+        return request -> {
+            byte[] rpIdHash = sha256(request.getApplication().getBytes(StandardCharsets.UTF_8));
+            byte[] authenticatorData = new byte[rpIdHash.length + 5];
+            System.arraycopy(rpIdHash, 0, authenticatorData, 0, rpIdHash.length);
+            authenticatorData[rpIdHash.length] = request.getMinFlags();
+            // counter = 1
+            authenticatorData[authenticatorData.length - 1] = 1;
+            byte[] signed = new byte[authenticatorData.length + request.getChallenge().length];
+            System.arraycopy(authenticatorData, 0, signed, 0, authenticatorData.length);
+            System.arraycopy(request.getChallenge(), 0, signed, authenticatorData.length, request.getChallenge().length);
+            try {
+                java.security.Signature s = java.security.Signature.getInstance("Ed25519");
+                s.initSign(credentialKey);
+                s.update(signed);
+                return new SecurityKeySignatureData(request.getMinFlags(), 1L, s.sign());
+            } catch (Exception e) {
+                throw new java.io.IOException(e);
+            }
+        };
+    }
+
+    private static byte[] sha256(byte[] data) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(data);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/hierynomus/sshj/userauth/method/AuthSecurityKeyTest.java
+++ b/src/test/java/com/hierynomus/sshj/userauth/method/AuthSecurityKeyTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.method;
+
+import com.hierynomus.sshj.test.SshServerExtension;
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPrivateKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeyPublicKey;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySignatureData;
+import com.hierynomus.sshj.userauth.fido.SecurityKeySigner;
+import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.common.KeyType;
+import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
+import net.schmizz.sshj.userauth.method.AuthPublickey;
+import org.apache.sshd.server.auth.pubkey.AcceptAllPublickeyAuthenticator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Authenticates to a real (in-process Apache MINA) SSH server using the {@code publickey} method
+ * with a {@link SecurityKeyPrivateKey}, i.e. through the {@link SecurityKeySigner} SPI rather than an
+ * agent. A software authenticator stands in for the YubiKey. This proves the non-agent SPI path
+ * works end-to-end and that the FIDO signature framing in the auth layer is accepted by an
+ * independent server.
+ */
+public class AuthSecurityKeyTest {
+
+    private static final String APPLICATION = "ssh:";
+    private static final byte FLAGS = 0x01;
+    private static final long COUNTER = 7L;
+
+    @RegisterExtension
+    public SshServerExtension fixture = new SshServerExtension(false);
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        fixture.getServer().setPublickeyAuthenticator(AcceptAllPublickeyAuthenticator.INSTANCE);
+        fixture.getServer().start();
+    }
+
+    @Test
+    public void authenticatesWithSkEcdsa() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(new ECGenParameterSpec("secp256r1"));
+        authenticatesWith(kpg.generateKeyPair(), KeyType.SK_ECDSA, "SHA256withECDSA");
+    }
+
+    @Test
+    public void authenticatesWithSkEd25519() throws Exception {
+        authenticatesWith(KeyPairGenerator.getInstance("Ed25519").generateKeyPair(), KeyType.SK_ED25519, "Ed25519");
+    }
+
+    private void authenticatesWith(KeyPair keyPair, KeyType keyType, String jcaAlgorithm) throws Exception {
+        SecurityKeyPublicKey publicKey = new SecurityKeyPublicKey(keyPair.getPublic(), APPLICATION);
+        SecurityKeySigner signer = softwareAuthenticator(keyPair.getPrivate(), jcaAlgorithm);
+        SecurityKeyPrivateKey privateKey = new SecurityKeyPrivateKey(keyType.toString(), publicKey, FLAGS, new byte[]{1, 2, 3, 4}, signer);
+
+        KeyProvider keyProvider = new KeyProvider() {
+            @Override
+            public PrivateKey getPrivate() {
+                return privateKey;
+            }
+
+            @Override
+            public PublicKey getPublic() {
+                return publicKey;
+            }
+
+            @Override
+            public KeyType getType() {
+                return keyType;
+            }
+        };
+
+        SSHClient client = fixture.setupConnectedDefaultClient();
+        client.auth("jeroen", new AuthPublickey(keyProvider));
+        assertTrue(client.isAuthenticated(), "client should authenticate with a security key via the SPI");
+    }
+
+    private static SecurityKeySigner softwareAuthenticator(PrivateKey credentialKey, String jcaAlgorithm) {
+        return request -> {
+            byte[] rpIdHash = sha256(request.getApplication().getBytes(StandardCharsets.UTF_8));
+            byte[] authenticatorData = new byte[rpIdHash.length + 5];
+            System.arraycopy(rpIdHash, 0, authenticatorData, 0, rpIdHash.length);
+            authenticatorData[rpIdHash.length] = FLAGS;
+            authenticatorData[rpIdHash.length + 1] = (byte) ((COUNTER >>> 24) & 0xff);
+            authenticatorData[rpIdHash.length + 2] = (byte) ((COUNTER >>> 16) & 0xff);
+            authenticatorData[rpIdHash.length + 3] = (byte) ((COUNTER >>> 8) & 0xff);
+            authenticatorData[rpIdHash.length + 4] = (byte) (COUNTER & 0xff);
+
+            byte[] signed = new byte[authenticatorData.length + request.getChallenge().length];
+            System.arraycopy(authenticatorData, 0, signed, 0, authenticatorData.length);
+            System.arraycopy(request.getChallenge(), 0, signed, authenticatorData.length, request.getChallenge().length);
+
+            try {
+                java.security.Signature s = java.security.Signature.getInstance(jcaAlgorithm);
+                s.initSign(credentialKey);
+                s.update(signed);
+                return new SecurityKeySignatureData(FLAGS, COUNTER, s.sign());
+            } catch (Exception e) {
+                throw new IOException("software authenticator failed", e);
+            }
+        };
+    }
+
+    private static byte[] sha256(byte[] data) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(data);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
# Description

A FIDO2 hardware key keeps its private key on the device, so nothing can sign without a physical tap. The usual sshj path of loading a private key and signing in process does not apply. OpenSSH covers this with two key types, `sk-ecdsa-sha2-nistp256@openssh.com` and `sk-ssh-ed25519@openssh.com`, and sshj recognised neither. The connection died before any signing, which blocks every client built on sshj (JetBrains IDEs, DBeaver) the moment a user has a security key.

This adds that support. sshj never touches USB or CTAP, where no mature pure-Java stack exists and Apache MINA sshd stopped short for the same reason. An SSH agent already holds the key and performs the tap, and it returns a finished signature, so sshj speaks the agent protocol and forwards the result. An application that drives the authenticator itself can implement a small signer interface instead.

# Changes

- Add the `sk-ecdsa-sha2-nistp256@openssh.com` and `sk-ssh-ed25519@openssh.com` key types: public-key parsing and serialisation, signature verification, and signature assembly. The verifier rebuilds the authenticator message `SHA256(application) || flags || counter || SHA256(data)` and checks it against the underlying ECDSA or Ed25519 key.
- Add an SSH agent client (`AgentProxy`, `AuthAgent`) over the `SSH_AUTH_SOCK` unix-domain socket. This also gives sshj general ssh-agent authentication for ordinary RSA, ECDSA and Ed25519 keys, which it did not have before. Main sources target Java 8, so the Java 16 socket is reached by reflection, and a caller can supply its own `AgentConnection` on older runtimes or other platforms.
- Add a `SecurityKeySigner` SPI for applications that drive the authenticator directly, and parse `sk-*` private keys from `openssh-key-v1` files.
- Register the new algorithms in `DefaultConfig` and route the security-key signature framing through the publickey auth method.

# How to test

New unit tests. They cover the public-key codec, signature verify and sign round trips, and authentication against an in-process Apache MINA server over both the agent path and the signer path. One test cross-checks sshj's signatures and public keys against MINA's independent `sk-*` implementation, which needs a test-only `net.i2p.crypto:eddsa` dependency.

Verified by hand with a YubiKey: the device produced `sk-ssh-ed25519` signatures with real authenticator flags and counters that the new verifier accepted, and a full login through `AuthAgent` authenticated against a server.

# Related issues

Fixes #766
