### PR TITLE
Add SSH agent authentication support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -58,6 +58,8 @@ In the `examples` directory, there is a separate Maven project that shows how th
 * reading known_hosts files for host key verification
 * publickey, password and keyboard-interactive authentication
 * SSH agent authentication over the `SSH_AUTH_SOCK` unix-domain socket (RSA, ECDSA, Ed25519, and FIDO/U2F security keys)
++
+NOTE: The built-in unix-domain socket transport requires a Java 16+ runtime. On older runtimes, supply your own `AgentConnection` implementation.
 * command, subsystem and shell channels
 * local and remote port forwarding
 * scp + complete sftp version 0-3 implementation

--- a/README.adoc
+++ b/README.adoc
@@ -57,6 +57,7 @@ In the `examples` directory, there is a separate Maven project that shows how th
 
 * reading known_hosts files for host key verification
 * publickey, password and keyboard-interactive authentication
+* SSH agent authentication over the `SSH_AUTH_SOCK` unix-domain socket (RSA, ECDSA, Ed25519, and FIDO/U2F security keys)
 * command, subsystem and shell channels
 * local and remote port forwarding
 * scp + complete sftp version 0-3 implementation

--- a/examples/src/main/java/net/schmizz/sshj/examples/SecurityKeyAgentAuth.java
+++ b/examples/src/main/java/net/schmizz/sshj/examples/SecurityKeyAgentAuth.java
@@ -1,0 +1,42 @@
+package net.schmizz.sshj.examples;
+
+import com.hierynomus.sshj.userauth.agent.AgentProxy;
+import com.hierynomus.sshj.userauth.agent.AuthAgent;
+import net.schmizz.sshj.SSHClient;
+import net.schmizz.sshj.connection.channel.direct.Session;
+
+import java.io.IOException;
+
+/**
+ * Authenticates with a FIDO/U2F security key (e.g. a YubiKey holding an {@code ed25519-sk} or
+ * {@code ecdsa-sk} key) by delegating to the system SSH agent.
+ * <p>
+ * Load the key into your agent once, then run this:
+ * <pre>
+ *   ssh-add ~/.ssh/id_ed25519_sk     # tap the key once to register it with the agent
+ *   ./run SecurityKeyAgentAuth
+ * </pre>
+ * The agent performs the hardware tap on every authentication, so sshj never has to talk to the
+ * authenticator directly. This also works for ordinary RSA/ECDSA/Ed25519 keys held by the agent.
+ */
+public class SecurityKeyAgentAuth {
+
+    public static void main(String... args) throws IOException {
+        final SSHClient ssh = new SSHClient();
+        ssh.loadKnownHosts();
+        ssh.connect("localhost");
+        // AgentProxy.fromEnvironment() connects to $SSH_AUTH_SOCK (requires a Java 16+ runtime for
+        // unix-domain sockets; supply your own AgentConnection on older JVMs or other platforms).
+        try (AgentProxy agent = AgentProxy.fromEnvironment()) {
+            ssh.auth(System.getProperty("user.name"), AuthAgent.fromIdentities(agent));
+            final Session session = ssh.startSession();
+            try {
+                session.exec("echo authenticated with a security key").join();
+            } finally {
+                session.close();
+            }
+        } finally {
+            ssh.disconnect();
+        }
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/AgentConnection.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/AgentConnection.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * A duplex byte channel to a running SSH authentication agent.
+ * <p>
+ * sshj ships {@link UnixSocketAgentConnection} for the {@code SSH_AUTH_SOCK} unix-domain socket
+ * used by OpenSSH on Linux and macOS. Implement this yourself to reach an agent over a different
+ * transport, e.g. a Windows named pipe / Pageant, or a socket your application already owns.
+ */
+public interface AgentConnection extends Closeable {
+
+    InputStream getInputStream() throws IOException;
+
+    OutputStream getOutputStream() throws IOException;
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/AgentIdentity.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/AgentIdentity.java
@@ -39,7 +39,7 @@ public class AgentIdentity {
 
     /** @return the exact key blob bytes as returned by the agent. */
     public byte[] getKeyBlob() {
-        return keyBlob;
+        return keyBlob.clone();
     }
 
     public String getComment() {

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/AgentIdentity.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/AgentIdentity.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import java.security.PublicKey;
+
+/**
+ * An identity held by an SSH agent: a public key, its exact wire encoding (the "key blob" that must
+ * be sent back verbatim in a sign request) and the human-readable comment.
+ */
+public class AgentIdentity {
+
+    private final PublicKey publicKey;
+    private final byte[] keyBlob;
+    private final String comment;
+
+    public AgentIdentity(PublicKey publicKey, byte[] keyBlob, String comment) {
+        this.publicKey = publicKey;
+        this.keyBlob = keyBlob;
+        this.comment = comment;
+    }
+
+    public PublicKey getPublicKey() {
+        return publicKey;
+    }
+
+    /** @return the exact key blob bytes as returned by the agent. */
+    public byte[] getKeyBlob() {
+        return keyBlob;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    @Override
+    public String toString() {
+        return "AgentIdentity{" + comment + ", " + publicKey.getAlgorithm() + "}";
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/AgentProxy.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/AgentProxy.java
@@ -101,7 +101,7 @@ public class AgentProxy implements Closeable {
                 try {
                     PublicKey publicKey = new Buffer.PlainBuffer(keyBlob).readPublicKey();
                     identities.add(new AgentIdentity(publicKey, keyBlob, comment));
-                } catch (Exception e) {
+                } catch (Buffer.BufferException e) {
                     log.debug("Skipping agent identity '{}' of unsupported key type: {}", comment, e.toString());
                 }
             }

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/AgentProxy.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/AgentProxy.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import net.schmizz.sshj.common.Buffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A client for the SSH authentication agent protocol (draft-miller-ssh-agent / OpenSSH's
+ * {@code PROTOCOL.agent}).
+ * <p>
+ * This is the recommended way to authenticate with a FIDO/U2F security key (an
+ * {@code sk-ecdsa-sha2-nistp256@openssh.com} or {@code sk-ssh-ed25519@openssh.com} key): load the
+ * key into your agent once with {@code ssh-add}, and the agent performs the hardware tap on every
+ * sign. The agent returns a fully formed SSH signature - including the security-key flags and
+ * counter - so sshj forwards it verbatim and never has to talk to the hardware itself.
+ * <p>
+ * It works for ordinary keys too (RSA, ECDSA, Ed25519), so it doubles as general ssh-agent support.
+ */
+public class AgentProxy implements Closeable {
+
+    private static final byte SSH_AGENT_FAILURE = 5;
+    private static final byte SSH_AGENTC_REQUEST_IDENTITIES = 11;
+    private static final byte SSH_AGENT_IDENTITIES_ANSWER = 12;
+    private static final byte SSH_AGENTC_SIGN_REQUEST = 13;
+    private static final byte SSH_AGENT_SIGN_RESPONSE = 14;
+
+    /** Sign flag asking the agent for an {@code rsa-sha2-256} signature from an RSA key. */
+    public static final int SSH_AGENT_RSA_SHA2_256 = 2;
+    /** Sign flag asking the agent for an {@code rsa-sha2-512} signature from an RSA key. */
+    public static final int SSH_AGENT_RSA_SHA2_512 = 4;
+
+    /** OpenSSH caps a single agent message at 256 KiB. */
+    private static final int AGENT_MAX_MESSAGE_LENGTH = 256 * 1024;
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final AgentConnection connection;
+    private final DataInputStream in;
+    private final OutputStream out;
+
+    public AgentProxy(AgentConnection connection) throws IOException {
+        this.connection = connection;
+        this.in = new DataInputStream(connection.getInputStream());
+        this.out = connection.getOutputStream();
+    }
+
+    /**
+     * Connect to the agent indicated by the {@code SSH_AUTH_SOCK} environment variable over a unix-
+     * domain socket. Requires a Java 16+ runtime; on older runtimes construct an {@link AgentProxy}
+     * with your own {@link AgentConnection}.
+     *
+     * @throws IOException if {@code SSH_AUTH_SOCK} is unset or the agent cannot be reached
+     */
+    public static AgentProxy fromEnvironment() throws IOException {
+        String socketPath = System.getenv("SSH_AUTH_SOCK");
+        if (socketPath == null || socketPath.isEmpty()) {
+            throw new IOException("SSH_AUTH_SOCK is not set; no SSH agent is available");
+        }
+        return new AgentProxy(new UnixSocketAgentConnection(socketPath));
+    }
+
+    /**
+     * List the identities the agent holds. Identities whose key type sshj does not understand are
+     * skipped (logged at debug), rather than failing the whole listing.
+     */
+    public synchronized List<AgentIdentity> getIdentities() throws IOException {
+        writeMessage(SSH_AGENTC_REQUEST_IDENTITIES, new byte[0]);
+        Response response = readMessage();
+        if (response.type != SSH_AGENT_IDENTITIES_ANSWER) {
+            throw new IOException("Unexpected response to agent identities request: type " + response.type);
+        }
+        Buffer.PlainBuffer buf = new Buffer.PlainBuffer(response.contents);
+        List<AgentIdentity> identities = new ArrayList<>();
+        try {
+            long count = buf.readUInt32();
+            for (long i = 0; i < count; i++) {
+                byte[] keyBlob = buf.readBytes();
+                String comment = buf.readString();
+                try {
+                    PublicKey publicKey = new Buffer.PlainBuffer(keyBlob).readPublicKey();
+                    identities.add(new AgentIdentity(publicKey, keyBlob, comment));
+                } catch (Exception e) {
+                    log.debug("Skipping agent identity '{}' of unsupported key type: {}", comment, e.toString());
+                }
+            }
+        } catch (Buffer.BufferException e) {
+            throw new IOException("Malformed agent identities answer", e);
+        }
+        return identities;
+    }
+
+    /**
+     * Ask the agent to sign {@code data} with the key identified by {@code keyBlob}.
+     *
+     * @param keyBlob the identity's key blob, exactly as returned by {@link #getIdentities()}
+     * @param data    the data to sign
+     * @param flags   sign flags, e.g. {@link #SSH_AGENT_RSA_SHA2_256}; {@code 0} for Ed25519 and
+     *                security keys
+     * @return the SSH signature value ({@code string signature_format || string signature_blob}, with
+     * any security-key flags and counter already appended by the agent), ready to be written as a
+     * single SSH {@code string}
+     */
+    public synchronized byte[] sign(byte[] keyBlob, byte[] data, int flags) throws IOException {
+        byte[] request = new Buffer.PlainBuffer()
+                .putBytes(keyBlob)
+                .putBytes(data)
+                .putUInt32(flags & 0xffffffffL)
+                .getCompactData();
+        writeMessage(SSH_AGENTC_SIGN_REQUEST, request);
+        Response response = readMessage();
+        if (response.type != SSH_AGENT_SIGN_RESPONSE) {
+            throw new IOException(response.type == SSH_AGENT_FAILURE
+                    ? "Agent declined to sign (it may not hold this key, or the user cancelled the touch/PIN)"
+                    : "Unexpected response to agent sign request: type " + response.type);
+        }
+        try {
+            return new Buffer.PlainBuffer(response.contents).readBytes();
+        } catch (Buffer.BufferException e) {
+            throw new IOException("Malformed agent sign response", e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        connection.close();
+    }
+
+    private void writeMessage(byte type, byte[] contents) throws IOException {
+        int length = 1 + contents.length;
+        byte[] header = new byte[]{
+                (byte) (length >>> 24), (byte) (length >>> 16), (byte) (length >>> 8), (byte) length, type
+        };
+        out.write(header);
+        out.write(contents);
+        out.flush();
+    }
+
+    private Response readMessage() throws IOException {
+        int length = in.readInt();
+        if (length <= 0 || length > AGENT_MAX_MESSAGE_LENGTH) {
+            throw new IOException("Illegal agent message length: " + length);
+        }
+        byte type = in.readByte();
+        byte[] contents = new byte[length - 1];
+        in.readFully(contents);
+        return new Response(type, contents);
+    }
+
+    private static final class Response {
+        private final byte type;
+        private final byte[] contents;
+
+        private Response(byte type, byte[] contents) {
+            this.type = type;
+            this.contents = contents;
+        }
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/AuthAgent.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/AuthAgent.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import com.hierynomus.sshj.key.KeyAlgorithm;
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.KeyType;
+import net.schmizz.sshj.common.Message;
+import net.schmizz.sshj.common.SSHPacket;
+import net.schmizz.sshj.transport.TransportException;
+import net.schmizz.sshj.userauth.UserAuthException;
+import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
+import net.schmizz.sshj.userauth.method.AuthMethod;
+import net.schmizz.sshj.userauth.method.KeyedAuthMethod;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The {@code "publickey"} authentication method backed by an SSH agent, for a single agent identity.
+ * <p>
+ * It behaves exactly like {@link net.schmizz.sshj.userauth.method.AuthPublickey} - send the public
+ * key, and on {@code SSH_MSG_USERAUTH_PK_OK} send a signed request - except the signature is
+ * produced by the {@link AgentProxy} (which drives the hardware, PIN and touch) and used verbatim.
+ * This is how FIDO/U2F security keys ({@code sk-*}) authenticate: the agent returns a complete
+ * signature with the security-key flags and counter already appended.
+ * <p>
+ * Use {@link #fromIdentities(AgentProxy)} to turn every identity the agent holds into a method:
+ * <pre>{@code
+ *   try (AgentProxy agent = AgentProxy.fromEnvironment()) {
+ *       ssh.auth(username, AuthAgent.fromIdentities(agent));
+ *   }
+ * }</pre>
+ */
+public class AuthAgent extends KeyedAuthMethod {
+
+    private final AgentProxy agent;
+    private final AgentIdentity identity;
+
+    public AuthAgent(AgentProxy agent, AgentIdentity identity) {
+        super("publickey", new AgentKeyProvider(identity));
+        this.agent = agent;
+        this.identity = identity;
+    }
+
+    /**
+     * Build one {@link AuthAgent} method per identity the agent currently holds, ready to hand to
+     * {@link net.schmizz.sshj.SSHClient#auth(String, Iterable)}.
+     */
+    public static List<AuthMethod> fromIdentities(AgentProxy agent) throws IOException {
+        List<AuthMethod> methods = new ArrayList<>();
+        for (AgentIdentity identity : agent.getIdentities()) {
+            methods.add(new AuthAgent(agent, identity));
+        }
+        return methods;
+    }
+
+    @Override
+    public void handle(Message cmd, SSHPacket buf) throws UserAuthException, TransportException {
+        if (cmd == Message.USERAUTH_60) {
+            sendSignedRequest();
+        } else {
+            super.handle(cmd, buf);
+        }
+    }
+
+    @Override
+    protected SSHPacket buildReq() throws UserAuthException {
+        // Feeler request, no signature.
+        return putPubKey(super.buildReq().putBoolean(false));
+    }
+
+    private void sendSignedRequest() throws UserAuthException, TransportException {
+        SSHPacket req = putPubKey(super.buildReq().putBoolean(true));
+        byte[] dataToSign = new Buffer.PlainBuffer()
+                .putString(params.getTransport().getSessionID())
+                .putBuffer(req)
+                .getCompactData();
+        byte[] signature;
+        try {
+            signature = agent.sign(identity.getKeyBlob(), dataToSign, agentSignFlags());
+        } catch (IOException e) {
+            throw new UserAuthException("SSH agent failed to sign for " + identity, e);
+        }
+        // The agent returns a fully formed SSH signature value; write it as a single string.
+        req.putString(signature);
+        params.getTransport().write(req);
+    }
+
+    @Override
+    protected SSHPacket putPubKey(SSHPacket reqBuf) throws UserAuthException {
+        KeyType keyType = identityType();
+        try {
+            KeyAlgorithm keyAlgorithm = getPublicKeyAlgorithm(keyType);
+            if (keyAlgorithm == null) {
+                throw new UserAuthException("No KeyAlgorithm configured for agent key " + keyType);
+            }
+            // Use the exact key blob the agent gave us, so signature verification matches byte-for-byte.
+            reqBuf.putString(keyAlgorithm.getKeyAlgorithm()).putString(identity.getKeyBlob());
+            return reqBuf;
+        } catch (TransportException e) {
+            throw new UserAuthException("No KeyAlgorithm configured for agent key " + keyType, e);
+        }
+    }
+
+    private int agentSignFlags() throws UserAuthException {
+        try {
+            KeyAlgorithm keyAlgorithm = getPublicKeyAlgorithm(identityType());
+            String name = keyAlgorithm == null ? "" : keyAlgorithm.getKeyAlgorithm();
+            if ("rsa-sha2-512".equals(name)) {
+                return AgentProxy.SSH_AGENT_RSA_SHA2_512;
+            }
+            if ("rsa-sha2-256".equals(name)) {
+                return AgentProxy.SSH_AGENT_RSA_SHA2_256;
+            }
+            return 0;
+        } catch (TransportException e) {
+            throw new UserAuthException("Could not resolve key algorithm for agent key", e);
+        }
+    }
+
+    private KeyType identityType() {
+        return KeyType.fromKey(identity.getPublicKey());
+    }
+
+    /** Exposes the agent identity's public key to {@link KeyedAuthMethod}; signing happens via the agent. */
+    private static final class AgentKeyProvider implements KeyProvider {
+        private final AgentIdentity identity;
+
+        private AgentKeyProvider(AgentIdentity identity) {
+            this.identity = identity;
+        }
+
+        @Override
+        public PrivateKey getPrivate() {
+            throw new UnsupportedOperationException("Agent-held keys are signed by the agent, not locally");
+        }
+
+        @Override
+        public PublicKey getPublic() {
+            return identity.getPublicKey();
+        }
+
+        @Override
+        public KeyType getType() {
+            return KeyType.fromKey(identity.getPublicKey());
+        }
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/agent/UnixSocketAgentConnection.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/agent/UnixSocketAgentConnection.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.net.SocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
+
+/**
+ * An {@link AgentConnection} over a unix-domain socket, as used by OpenSSH's {@code SSH_AUTH_SOCK}
+ * on Linux and macOS.
+ * <p>
+ * Unix-domain sockets are only in the JDK from Java 16 onwards. sshj's main sources target Java 8,
+ * so the Java 16 socket classes are reached reflectively here: this compiles everywhere and works
+ * at runtime on a Java 16+ JVM (such as the JetBrains Runtime). On an older runtime the constructor
+ * throws an {@link IOException} explaining that you must supply your own {@link AgentConnection}.
+ */
+public class UnixSocketAgentConnection implements AgentConnection {
+
+    private final SocketChannel channel;
+    private final InputStream in;
+    private final OutputStream out;
+
+    public UnixSocketAgentConnection(String socketPath) throws IOException {
+        this.channel = openUnixSocketChannel(socketPath);
+        this.in = Channels.newInputStream(channel);
+        this.out = Channels.newOutputStream(channel);
+    }
+
+    private static SocketChannel openUnixSocketChannel(String socketPath) throws IOException {
+        try {
+            // Equivalent to (Java 16+):
+            //   SocketChannel ch = SocketChannel.open(StandardProtocolFamily.UNIX);
+            //   ch.connect(UnixDomainSocketAddress.of(socketPath));
+            Class<?> standardProtocolFamily = Class.forName("java.net.StandardProtocolFamily");
+            Object unix = standardProtocolFamily.getField("UNIX").get(null);
+
+            Class<?> unixDomainSocketAddress = Class.forName("java.net.UnixDomainSocketAddress");
+            SocketAddress address = (SocketAddress) unixDomainSocketAddress
+                    .getMethod("of", String.class).invoke(null, socketPath);
+
+            Method open = SocketChannel.class.getMethod("open", Class.forName("java.net.ProtocolFamily"));
+            SocketChannel channel = (SocketChannel) open.invoke(null, unix);
+            try {
+                channel.connect(address);
+            } catch (IOException e) {
+                channel.close();
+                throw e;
+            }
+            return channel;
+        } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException e) {
+            throw new IOException("Unix-domain socket support requires a Java 16+ runtime. "
+                    + "On an older runtime, connect to the agent yourself and pass a custom AgentConnection.", e);
+        } catch (ReflectiveOperationException e) {
+            throw new IOException("Failed to open unix-domain socket to SSH agent at " + socketPath, e);
+        }
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return in;
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return out;
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+    }
+}

--- a/src/main/java/net/schmizz/sshj/userauth/method/KeyedAuthMethod.java
+++ b/src/main/java/net/schmizz/sshj/userauth/method/KeyedAuthMethod.java
@@ -34,7 +34,7 @@ public abstract class KeyedAuthMethod
         extends AbstractAuthMethod {
 
     protected final KeyProvider kProv;
-    protected Queue<KeyAlgorithm> available;
+    private Queue<KeyAlgorithm> available;
 
     public KeyedAuthMethod(String name, KeyProvider kProv) {
         super(name);

--- a/src/main/java/net/schmizz/sshj/userauth/method/KeyedAuthMethod.java
+++ b/src/main/java/net/schmizz/sshj/userauth/method/KeyedAuthMethod.java
@@ -34,14 +34,14 @@ public abstract class KeyedAuthMethod
         extends AbstractAuthMethod {
 
     protected final KeyProvider kProv;
-    private Queue<KeyAlgorithm> available;
+    protected Queue<KeyAlgorithm> available;
 
     public KeyedAuthMethod(String name, KeyProvider kProv) {
         super(name);
         this.kProv = kProv;
     }
 
-    private KeyAlgorithm getPublicKeyAlgorithm(KeyType keyType) throws TransportException {
+    protected KeyAlgorithm getPublicKeyAlgorithm(KeyType keyType) throws TransportException {
         if (available == null) {
             available = new LinkedList<>(params.getTransport().getClientKeyAlgorithms(keyType));
         }

--- a/src/test/java/com/hierynomus/sshj/userauth/agent/AgentProxyLiveTest.java
+++ b/src/test/java/com/hierynomus/sshj/userauth/agent/AgentProxyLiveTest.java
@@ -24,10 +24,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.nio.charset.StandardCharsets;
+import java.security.interfaces.RSAPublicKey;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * End-to-end test against a real, running ssh-agent over a unix-domain socket. It exercises the
@@ -58,6 +62,41 @@ public class AgentProxyLiveTest {
                 verifier.update(data);
                 assertTrue(verifier.verify(signature),
                         "agent signature should verify for " + identity + " (" + signatureType + ")");
+            }
+        }
+    }
+
+    @Test
+    public void rsaKeysProduceVerifiableSha2Signatures() throws Exception {
+        String socketPath = System.getenv("SSHJ_TEST_AGENT_SOCK");
+        try (AgentProxy agent = new AgentProxy(new UnixSocketAgentConnection(socketPath))) {
+            List<AgentIdentity> rsaIdentities = agent.getIdentities().stream()
+                    .filter(id -> id.getPublicKey() instanceof RSAPublicKey)
+                    .collect(Collectors.toList());
+            assumeTrue(!rsaIdentities.isEmpty(), "skipping: no RSA identities in the test agent");
+
+            byte[] data = "sshj rsa sha2 live test challenge".getBytes(StandardCharsets.UTF_8);
+            for (AgentIdentity identity : rsaIdentities) {
+                for (int[] flagAndExpectedName : new int[][]{
+                        {AgentProxy.SSH_AGENT_RSA_SHA2_256, 0},
+                        {AgentProxy.SSH_AGENT_RSA_SHA2_512, 1}
+                }) {
+                    int flag = flagAndExpectedName[0];
+                    String expectedSigName = flag == AgentProxy.SSH_AGENT_RSA_SHA2_256
+                            ? "rsa-sha2-256" : "rsa-sha2-512";
+
+                    byte[] signature = agent.sign(identity.getKeyBlob(), data, flag);
+
+                    String actualSigName = new Buffer.PlainBuffer(signature).readString();
+                    assertEquals(expectedSigName, actualSigName,
+                            "agent should produce " + expectedSigName + " signature for " + identity);
+
+                    Signature verifier = signatureForType(actualSigName);
+                    verifier.initVerify(identity.getPublicKey());
+                    verifier.update(data);
+                    assertTrue(verifier.verify(signature),
+                            expectedSigName + " agent signature should verify for " + identity);
+                }
             }
         }
     }

--- a/src/test/java/com/hierynomus/sshj/userauth/agent/AgentProxyLiveTest.java
+++ b/src/test/java/com/hierynomus/sshj/userauth/agent/AgentProxyLiveTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import com.hierynomus.sshj.key.KeyAlgorithm;
+import net.schmizz.sshj.DefaultConfig;
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.Factory;
+import net.schmizz.sshj.signature.Signature;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end test against a real, running ssh-agent over a unix-domain socket. It exercises the
+ * reflective {@link UnixSocketAgentConnection}, identity listing and the sign request, then verifies
+ * the agent's signature with sshj's own signature machinery.
+ * <p>
+ * Opt-in: it only runs when {@code SSHJ_TEST_AGENT_SOCK} points at an agent socket that holds at
+ * least one key, so ordinary CI is unaffected. See {@code AgentLiveTest} orchestration in the PR
+ * notes for how to drive it. Requires a Java 16+ runtime for unix-domain sockets.
+ */
+@EnabledIfEnvironmentVariable(named = "SSHJ_TEST_AGENT_SOCK", matches = ".+")
+public class AgentProxyLiveTest {
+
+    @Test
+    public void listsIdentitiesAndProducesVerifiableSignatures() throws Exception {
+        String socketPath = System.getenv("SSHJ_TEST_AGENT_SOCK");
+        try (AgentProxy agent = new AgentProxy(new UnixSocketAgentConnection(socketPath))) {
+            List<AgentIdentity> identities = agent.getIdentities();
+            assertFalse(identities.isEmpty(), "the test agent should hold at least one identity");
+
+            byte[] data = "sshj agent live test challenge".getBytes(StandardCharsets.UTF_8);
+            for (AgentIdentity identity : identities) {
+                byte[] signature = agent.sign(identity.getKeyBlob(), data, 0);
+
+                String signatureType = new Buffer.PlainBuffer(signature).readString();
+                Signature verifier = signatureForType(signatureType);
+                verifier.initVerify(identity.getPublicKey());
+                verifier.update(data);
+                assertTrue(verifier.verify(signature),
+                        "agent signature should verify for " + identity + " (" + signatureType + ")");
+            }
+        }
+    }
+
+    private static Signature signatureForType(String signatureName) {
+        for (Factory.Named<KeyAlgorithm> factory : new DefaultConfig().getKeyAlgorithms()) {
+            Signature signature = factory.create().newSignature();
+            if (signature.getSignatureName().equals(signatureName)) {
+                return signature;
+            }
+        }
+        throw new IllegalStateException("No registered Signature for agent signature type: " + signatureName);
+    }
+}

--- a/src/test/java/com/hierynomus/sshj/userauth/agent/AuthAgentTest.java
+++ b/src/test/java/com/hierynomus/sshj/userauth/agent/AuthAgentTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import com.hierynomus.sshj.test.SshServerExtension;
+import net.schmizz.sshj.SSHClient;
+import org.apache.sshd.server.auth.pubkey.AcceptAllPublickeyAuthenticator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Authenticates to a real (in-process Apache MINA) SSH server via {@link AuthAgent}, with signing
+ * delegated to an in-memory {@link FakeSshAgent}. This proves the full agent auth flow: the agent
+ * lists the identity, the server sends PK_OK, the agent signs the userauth blob, and the server
+ * verifies the signature. (A FIDO security key authenticates by exactly this path, with a YubiKey
+ * standing in for the fake agent.)
+ */
+public class AuthAgentTest {
+
+    @RegisterExtension
+    public SshServerExtension fixture = new SshServerExtension(false);
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        fixture.getServer().setPublickeyAuthenticator(AcceptAllPublickeyAuthenticator.INSTANCE);
+        fixture.getServer().start();
+    }
+
+    @Test
+    public void authenticatesWithEd25519AgentKey() throws Exception {
+        authenticatesWith(KeyPairGenerator.getInstance("Ed25519").generateKeyPair(), "ed25519-agent-key");
+    }
+
+    @Test
+    public void authenticatesWithEcdsaAgentKey() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(new java.security.spec.ECGenParameterSpec("secp256r1"));
+        authenticatesWith(kpg.generateKeyPair(), "ecdsa-agent-key");
+    }
+
+    private void authenticatesWith(KeyPair keyPair, String comment) throws Exception {
+        try (FakeSshAgent fakeAgent = new FakeSshAgent()
+                .addIdentity(keyPair.getPublic(), keyPair.getPrivate(), comment)
+                .start()) {
+            AgentProxy agent = new AgentProxy(fakeAgent.connection());
+
+            List<AgentIdentity> identities = agent.getIdentities();
+            assertEquals(1, identities.size());
+            assertEquals(comment, identities.get(0).getComment());
+
+            SSHClient client = fixture.setupConnectedDefaultClient();
+            client.auth("jeroen", new AuthAgent(agent, identities.get(0)));
+            assertTrue(client.isAuthenticated(), "client should authenticate via the agent");
+        }
+    }
+}

--- a/src/test/java/com/hierynomus/sshj/userauth/agent/FakeSshAgent.java
+++ b/src/test/java/com/hierynomus/sshj/userauth/agent/FakeSshAgent.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.agent;
+
+import net.schmizz.sshj.common.Buffer;
+import net.schmizz.sshj.common.KeyType;
+import net.schmizz.sshj.signature.Signature;
+
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A minimal in-memory SSH agent for tests: it speaks the agent wire protocol over loopback pipes and
+ * signs with software keys. This lets the agent auth path be tested end-to-end against a real SSH
+ * server without any external agent process or hardware.
+ */
+class FakeSshAgent implements Closeable {
+
+    private static final byte SSH_AGENT_FAILURE = 5;
+    private static final byte SSH_AGENTC_REQUEST_IDENTITIES = 11;
+    private static final byte SSH_AGENT_IDENTITIES_ANSWER = 12;
+    private static final byte SSH_AGENTC_SIGN_REQUEST = 13;
+    private static final byte SSH_AGENT_SIGN_RESPONSE = 14;
+
+    private static final class Identity {
+        final byte[] keyBlob;
+        final String comment;
+        final PrivateKey privateKey;
+        final Signature signature;
+
+        Identity(byte[] keyBlob, String comment, PrivateKey privateKey, Signature signature) {
+            this.keyBlob = keyBlob;
+            this.comment = comment;
+            this.privateKey = privateKey;
+            this.signature = signature;
+        }
+    }
+
+    private final List<Identity> identities = new ArrayList<>();
+    private final DataInputStream agentIn;
+    private final OutputStream agentOut;
+    private final InputStream clientIn;
+    private final OutputStream clientOut;
+    private final Thread thread;
+
+    FakeSshAgent() throws IOException {
+        PipedInputStream clientToAgent = new PipedInputStream(1 << 16);
+        PipedOutputStream clientWrites = new PipedOutputStream(clientToAgent);
+        PipedInputStream agentToClient = new PipedInputStream(1 << 16);
+        PipedOutputStream agentWrites = new PipedOutputStream(agentToClient);
+
+        this.agentIn = new DataInputStream(clientToAgent);
+        this.agentOut = agentWrites;
+        this.clientIn = agentToClient;
+        this.clientOut = clientWrites;
+
+        this.thread = new Thread(this::serve, "fake-ssh-agent");
+        this.thread.setDaemon(true);
+    }
+
+    FakeSshAgent addIdentity(PublicKey publicKey, PrivateKey privateKey, String comment) {
+        byte[] keyBlob = new Buffer.PlainBuffer().putPublicKey(publicKey).getCompactData();
+        Signature signature = signatureFor(KeyType.fromKey(publicKey));
+        identities.add(new Identity(keyBlob, comment, privateKey, signature));
+        return this;
+    }
+
+    FakeSshAgent start() {
+        thread.start();
+        return this;
+    }
+
+    AgentConnection connection() {
+        return new AgentConnection() {
+            @Override
+            public InputStream getInputStream() {
+                return clientIn;
+            }
+
+            @Override
+            public OutputStream getOutputStream() {
+                return clientOut;
+            }
+
+            @Override
+            public void close() {
+                // The proxy closing its side ends the serve loop via EOF.
+            }
+        };
+    }
+
+    private void serve() {
+        try {
+            while (true) {
+                int length = agentIn.readInt();
+                byte type = agentIn.readByte();
+                byte[] contents = new byte[length - 1];
+                agentIn.readFully(contents);
+                handle(type, contents);
+            }
+        } catch (IOException eof) {
+            // pipe closed -> stop
+        }
+    }
+
+    private void handle(byte type, byte[] contents) throws IOException {
+        switch (type) {
+            case SSH_AGENTC_REQUEST_IDENTITIES:
+                Buffer.PlainBuffer answer = new Buffer.PlainBuffer().putUInt32(identities.size());
+                for (Identity identity : identities) {
+                    answer.putBytes(identity.keyBlob).putString(identity.comment);
+                }
+                writeMessage(SSH_AGENT_IDENTITIES_ANSWER, answer.getCompactData());
+                break;
+            case SSH_AGENTC_SIGN_REQUEST:
+                signRequest(contents);
+                break;
+            default:
+                writeMessage(SSH_AGENT_FAILURE, new byte[0]);
+        }
+    }
+
+    private void signRequest(byte[] contents) throws IOException {
+        try {
+            Buffer.PlainBuffer request = new Buffer.PlainBuffer(contents);
+            byte[] keyBlob = request.readBytes();
+            byte[] data = request.readBytes();
+            request.readUInt32(); // flags, ignored by this fake (no RSA-SHA2)
+
+            Identity identity = findIdentity(keyBlob);
+            if (identity == null) {
+                writeMessage(SSH_AGENT_FAILURE, new byte[0]);
+                return;
+            }
+            identity.signature.initSign(identity.privateKey);
+            identity.signature.update(data);
+            byte[] signatureValue = new Buffer.PlainBuffer()
+                    .putString(identity.signature.getSignatureName())
+                    .putBytes(identity.signature.encode(identity.signature.sign()))
+                    .getCompactData();
+            writeMessage(SSH_AGENT_SIGN_RESPONSE, new Buffer.PlainBuffer().putBytes(signatureValue).getCompactData());
+        } catch (Buffer.BufferException e) {
+            writeMessage(SSH_AGENT_FAILURE, new byte[0]);
+        }
+    }
+
+    private Identity findIdentity(byte[] keyBlob) {
+        for (Identity identity : identities) {
+            if (java.util.Arrays.equals(identity.keyBlob, keyBlob)) {
+                return identity;
+            }
+        }
+        return null;
+    }
+
+    private void writeMessage(byte type, byte[] contents) throws IOException {
+        int length = 1 + contents.length;
+        agentOut.write(new byte[]{
+                (byte) (length >>> 24), (byte) (length >>> 16), (byte) (length >>> 8), (byte) length, type
+        });
+        agentOut.write(contents);
+        agentOut.flush();
+    }
+
+    private static Signature signatureFor(KeyType keyType) {
+        for (net.schmizz.sshj.common.Factory.Named<com.hierynomus.sshj.key.KeyAlgorithm> factory : new net.schmizz.sshj.DefaultConfig().getKeyAlgorithms()) {
+            com.hierynomus.sshj.key.KeyAlgorithm keyAlgorithm = factory.create();
+            if (keyAlgorithm.getKeyFormat() == keyType) {
+                return keyAlgorithm.newSignature();
+            }
+        }
+        throw new IllegalArgumentException("No signature available for key type " + keyType);
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            clientIn.close();
+            clientOut.close();
+            agentOut.close();
+            agentIn.close();
+        } finally {
+            thread.interrupt();
+        }
+    }
+}


### PR DESCRIPTION
# Description

sshj had no SSH agent support, so an application could not authenticate with a key that ssh-agent holds. This adds an agent client and an agent-backed `publickey` method. It works for ordinary RSA, ECDSA and Ed25519 keys, and it is also the practical route for FIDO/U2F security keys: the agent runs the touch and returns a finished signature, so sshj forwards it and never talks to the hardware. The `sk-*` key types themselves come in #1043.

# Changes

- Add an SSH agent protocol client (`AgentProxy`) that lists identities and requests signatures, including the RSA-SHA2 sign flags.
- Add `AuthAgent`, a `publickey` auth method backed by an agent identity. It reuses the existing key-algorithm negotiation and writes the agent's signature verbatim.
- Add a pluggable `AgentConnection` with a built-in unix-domain-socket transport for `SSH_AUTH_SOCK`. Main sources target Java 8, so the Java 16 socket is reached by reflection, and a caller can supply its own connection on older runtimes or other platforms such as a Windows named pipe.
- Widen two `KeyedAuthMethod` members to `protected` so `AuthAgent` can reuse them.

# How to test

New unit tests. They authenticate to an in-process Apache MINA server through `AuthAgent`, with an in-memory agent signing for Ed25519 and ECDSA keys. An opt-in test driven by `SSHJ_TEST_AGENT_SOCK` runs the same flow against a real agent over the socket.

# Related issues

Groundwork for #766. The `sk-*` key types that make use of this are in #1043.

This PR and #1043 both edit `README` and `KeyedAuthMethod`, so whichever merges second needs a trivial rebase.
