### PR TITLE
Prefer strongest signature algorithm for known RSA hosts

### DIFF
--- a/src/main/java/net/schmizz/sshj/transport/Proposal.java
+++ b/src/main/java/net/schmizz/sshj/transport/Proposal.java
@@ -15,15 +15,20 @@
  */
 package net.schmizz.sshj.transport;
 
+import com.hierynomus.sshj.key.KeyAlgorithm;
+import com.hierynomus.sshj.key.KeyAlgorithms;
 import net.schmizz.sshj.Config;
 import net.schmizz.sshj.common.Buffer;
 import net.schmizz.sshj.common.Factory;
+import net.schmizz.sshj.common.KeyType;
 import net.schmizz.sshj.common.Message;
 import net.schmizz.sshj.common.SSHPacket;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 class Proposal {
 
@@ -42,7 +47,7 @@ class Proposal {
         if (initialKex) {
             kex.add("kex-strict-c-v00@openssh.com");
         }
-        sig = filterKnownHostKeyAlgorithms(Factory.Named.Util.getNames(config.getKeyAlgorithms()), knownHostAlgs);
+        sig = filterKnownHostKeyAlgorithms(config.getKeyAlgorithms(), knownHostAlgs);
         c2sCipher = s2cCipher = Factory.Named.Util.getNames(config.getCipherFactories());
         c2sMAC = s2cMAC = Factory.Named.Util.getNames(config.getMACFactories());
         c2sComp = s2cComp = Factory.Named.Util.getNames(config.getCompressionFactories());
@@ -150,26 +155,44 @@ class Proposal {
         );
     }
 
-    private List<String> filterKnownHostKeyAlgorithms(List<String> configuredKeyAlgorithms, List<String> knownHostKeyAlgorithms) {
-        if (knownHostKeyAlgorithms != null && !knownHostKeyAlgorithms.isEmpty()) {
-            List<String> preferredAlgorithms = new ArrayList<String>();
-            List<String> otherAlgorithms = new ArrayList<String>();
-
-            for (String configuredKeyAlgorithm : configuredKeyAlgorithms) {
-                if (knownHostKeyAlgorithms.contains(configuredKeyAlgorithm)) {
-                    preferredAlgorithms.add(configuredKeyAlgorithm);
-                } else {
-                    otherAlgorithms.add(configuredKeyAlgorithm);
-                }
-            }
-
-            preferredAlgorithms.addAll(otherAlgorithms);
-
-            return preferredAlgorithms;
-        } else {
-            return configuredKeyAlgorithms;
+    private List<String> filterKnownHostKeyAlgorithms(List<Factory.Named<KeyAlgorithm>> configuredKeyAlgorithms, List<String> knownHostKeyAlgorithms) {
+        if (knownHostKeyAlgorithms == null || knownHostKeyAlgorithms.isEmpty()) {
+            return Factory.Named.Util.getNames(configuredKeyAlgorithms);
         }
 
+        // A known_hosts entry only records the host key *type*: an RSA host key is always stored as
+        // "ssh-rsa", regardless of whether the server signs with ssh-rsa, rsa-sha2-256 or rsa-sha2-512.
+        // Matching the stored name against the configured signature algorithm names would therefore only
+        // ever promote the legacy ssh-rsa and bury the rsa-sha2-* algorithms. Match on the key type
+        // instead, so every configured signature algorithm for a known key type is preferred while
+        // keeping the configured order (which prefers rsa-sha2-* over ssh-rsa).
+        Set<KeyType> knownHostKeyTypes = EnumSet.noneOf(KeyType.class);
+        for (String knownHostKeyAlgorithm : knownHostKeyAlgorithms) {
+            knownHostKeyTypes.add(KeyType.fromString(knownHostKeyAlgorithm));
+        }
+        knownHostKeyTypes.remove(KeyType.UNKNOWN);
+
+        List<String> preferredAlgorithms = new ArrayList<String>();
+        List<String> otherAlgorithms = new ArrayList<String>();
+
+        for (Factory.Named<KeyAlgorithm> configuredKeyAlgorithm : configuredKeyAlgorithms) {
+            if (knownHostKeyTypes.contains(keyTypeOf(configuredKeyAlgorithm))) {
+                preferredAlgorithms.add(configuredKeyAlgorithm.getName());
+            } else {
+                otherAlgorithms.add(configuredKeyAlgorithm.getName());
+            }
+        }
+
+        preferredAlgorithms.addAll(otherAlgorithms);
+
+        return preferredAlgorithms;
+    }
+
+    private static KeyType keyTypeOf(Factory.Named<KeyAlgorithm> keyAlgorithm) {
+        if (keyAlgorithm instanceof KeyAlgorithms.Factory) {
+            return ((KeyAlgorithms.Factory) keyAlgorithm).getKeyType();
+        }
+        return KeyType.fromString(keyAlgorithm.getName());
     }
 
     private static String firstMatch(String ofWhat, List<String> a, List<String> b)

--- a/src/test/java/net/schmizz/sshj/transport/ProposalTest.java
+++ b/src/test/java/net/schmizz/sshj/transport/ProposalTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.schmizz.sshj.transport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import net.schmizz.sshj.DefaultConfig;
+import net.schmizz.sshj.common.Factory;
+import org.junit.jupiter.api.Test;
+
+public class ProposalTest {
+
+    private List<String> configuredKeyAlgorithms() {
+        return Factory.Named.Util.getNames(new DefaultConfig().getKeyAlgorithms());
+    }
+
+    private List<String> hostKeyAlgorithmsFor(List<String> knownHostAlgs) {
+        return new Proposal(new DefaultConfig(), knownHostAlgs, false).getHostKeyAlgorithms();
+    }
+
+    @Test
+    public void withoutKnownHostAlgorithmsTheConfiguredOrderIsKept() {
+        assertEquals(configuredKeyAlgorithms(), hostKeyAlgorithmsFor(Collections.<String>emptyList()));
+        assertEquals(configuredKeyAlgorithms(), hostKeyAlgorithmsFor(null));
+    }
+
+    @Test
+    public void knownHostRsaKeyPrefersEveryRsaSignatureAlgorithmInConfiguredOrder() {
+        // known_hosts stores an RSA key as "ssh-rsa" regardless of the signature algorithm the
+        // server actually uses, so all three RSA signature algorithms must be preferred - and the
+        // modern rsa-sha2-* variants must stay ahead of the legacy ssh-rsa (SHA-1).
+        List<String> algorithms = hostKeyAlgorithmsFor(Collections.singletonList("ssh-rsa"));
+
+        assertEquals(Arrays.asList("rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"),
+                onlyRsa(algorithms));
+        assertEquals(Arrays.asList("rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"),
+                algorithms.subList(0, 3));
+    }
+
+    @Test
+    public void knownHostNonRsaKeyDoesNotReorderRsaSignatureAlgorithms() {
+        List<String> algorithms = hostKeyAlgorithmsFor(Collections.singletonList("ssh-ed25519"));
+
+        assertEquals("ssh-ed25519", algorithms.get(0));
+        // no spurious reordering of the RSA algorithms relative to each other
+        assertEquals(Arrays.asList("rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"), onlyRsa(algorithms));
+        assertTrue(algorithms.containsAll(configuredKeyAlgorithms()));
+    }
+
+    @Test
+    public void knownHostRsaCertificateIsMatchedByKeyType() {
+        // A certificate key type is distinct from its plain key type: an "ssh-rsa-cert-v01@openssh.com"
+        // known host must prefer the certificate algorithm, not the plain rsa-sha2-* / ssh-rsa ones.
+        List<String> algorithms = hostKeyAlgorithmsFor(
+                Collections.singletonList("ssh-rsa-cert-v01@openssh.com"));
+
+        assertEquals("ssh-rsa-cert-v01@openssh.com", algorithms.get(0));
+        assertEquals(Arrays.asList("rsa-sha2-512", "rsa-sha2-256", "ssh-rsa"), onlyRsa(algorithms));
+    }
+
+    @Test
+    public void unknownKnownHostAlgorithmIsIgnored() {
+        assertEquals(configuredKeyAlgorithms(),
+                hostKeyAlgorithmsFor(Collections.singletonList("some-future-algorithm@openssh.com")));
+    }
+
+    private static List<String> onlyRsa(List<String> algorithms) {
+        List<String> rsa = new java.util.ArrayList<>();
+        for (String algorithm : algorithms) {
+            if (algorithm.equals("ssh-rsa") || algorithm.startsWith("rsa-sha2-")) {
+                rsa.add(algorithm);
+            }
+        }
+        return rsa;
+    }
+}


### PR DESCRIPTION
filterKnownHostKeyAlgorithms promotes the algorithms recorded in known_hosts to the front of the client proposal so a known host is verified with the same algorithm it was recorded with. A known_hosts entry only records the host key *type* though: an RSA key is always stored as "ssh-rsa", whether the server signs with ssh-rsa, rsa-sha2-256 or rsa-sha2-512. Comparing that stored name against the configured signature algorithm names only ever promoted the legacy ssh-rsa, so for a known RSA host sshj would negotiate a SHA-1 signature even when both peers also support rsa-sha2-512/256.

Match on the resolved KeyType instead, so every configured signature algorithm for a known key type is promoted together while keeping the configured order (which already prefers rsa-sha2-* over ssh-rsa). Certificate key types get the same treatment. This is a behavioural improvement, not a functional bug fix - negotiation already succeeds today, just with a weaker signature than necessary. Supersedes the hard-coded reordering proposed in #1023.