### PR TITLE
Fix/opensshv1 keyfile public key init

### DIFF
--- a/src/main/java/com/hierynomus/sshj/userauth/keyprovider/CompanionPublicKey.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/keyprovider/CompanionPublicKey.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C)2009 - SSHJ Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hierynomus.sshj.userauth.keyprovider;
+
+import net.schmizz.sshj.common.KeyType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.security.PublicKey;
+
+/**
+ * The public key - or certificate - provided alongside a private key for the OpenSSH key file
+ * providers ({@link net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile} and
+ * {@link OpenSSHKeyV1KeyFile}). It can be supplied next to the private key as a {@code .pub} /
+ * {@code -cert.pub} file, or explicitly as a string or a stream. When none was supplied, the
+ * providers fall back to the public key embedded in the private key file.
+ * <p>
+ * A parse failure is logged and otherwise ignored, again letting the provider fall back to the
+ * embedded public key.
+ */
+public class CompanionPublicKey {
+
+    private static final Logger log = LoggerFactory.getLogger(CompanionPublicKey.class);
+
+    private KeyType type;
+    private PublicKey publicKey;
+
+    /** Load the {@code .pub} / {@code -cert.pub} file that sits next to the given private key file, if any. */
+    public void loadSiblingOf(File privateKeyLocation) {
+        File publicKeyFile = OpenSSHKeyFileUtil.getPublicKeyFile(privateKeyLocation);
+        if (publicKeyFile != null) {
+            try {
+                parse(new FileReader(publicKeyFile));
+            } catch (IOException e) {
+                // let the provider fall back to the public key embedded in the private key file
+                log.warn("Error reading public key file: {}", e.toString());
+            }
+        }
+    }
+
+    /** Load the public key from the given string, or do nothing when it is {@code null}. */
+    public void load(String publicKey) {
+        if (publicKey != null) {
+            load(new StringReader(publicKey));
+        }
+    }
+
+    /** Load the public key from the given stream, or do nothing when it is {@code null}. */
+    public void load(Reader publicKey) {
+        if (publicKey != null) {
+            try {
+                parse(publicKey);
+            } catch (IOException e) {
+                // let the provider fall back to the public key embedded in the private key file
+                log.warn("Error reading public key: {}", e.toString());
+            }
+        }
+    }
+
+    private void parse(Reader reader) throws IOException {
+        OpenSSHKeyFileUtil.ParsedPubKey parsed = OpenSSHKeyFileUtil.initPubKey(reader);
+        type = parsed.getType();
+        publicKey = parsed.getPubKey();
+    }
+
+    public boolean isPresent() {
+        return publicKey != null;
+    }
+
+    public PublicKey getPublicKey() {
+        return publicKey;
+    }
+
+    public KeyType getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
@@ -114,10 +114,10 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
 
     @Override
     public void init(File location, PasswordFinder pwdf) {
-        File pubKey = OpenSSHKeyFileUtil.getPublicKeyFile(location);
-        if (pubKey != null) {
+        File publicKeyFile = OpenSSHKeyFileUtil.getPublicKeyFile(location);
+        if (publicKeyFile != null) {
             try {
-                initPubKey(new FileReader(pubKey));
+                initPubKey(new FileReader(publicKeyFile));
             } catch (IOException e) {
                 // let super provide both public & private key
                 log.warn("Error reading public key file: {}", e.toString());
@@ -128,11 +128,12 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
 
     @Override
     public void init(String privateKey, String publicKey, PasswordFinder pwdf) {
-        if (pubKey != null) {
+        if (publicKey != null) {
             try {
                 initPubKey(new StringReader(publicKey));
             } catch (IOException e) {
-                log.warn("Error reading public key file: {}", e.toString());
+                // let super provide both public & private key
+                log.warn("Error reading public key: {}", e.toString());
             }
         }
         super.init(privateKey, null, pwdf);
@@ -140,11 +141,12 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
 
     @Override
     public void init(Reader privateKey, Reader publicKey, PasswordFinder pwdf) {
-        if (pubKey != null) {
+        if (publicKey != null) {
             try {
                 initPubKey(publicKey);
             } catch (IOException e) {
-                log.warn("Error reading public key file: {}", e.toString());
+                // let super provide both public & private key
+                log.warn("Error reading public key: {}", e.toString());
             }
         }
         super.init(privateKey, null, pwdf);
@@ -364,11 +366,11 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
                 byte[] privKey = new byte[32];
                 keyBuffer.readRawBytes(privKey); // string privatekey
 
-                final byte[] pubKey = new byte[32];
-                keyBuffer.readRawBytes(pubKey); // string publickey (again...)
+                final byte[] pubKeyBytes = new byte[32];
+                keyBuffer.readRawBytes(pubKeyBytes); // string publickey (again...)
 
                 final PrivateKey edPrivateKey = Ed25519KeyFactory.getPrivateKey(privKey);
-                final PublicKey edPublicKey = Ed25519KeyFactory.getPublicKey(pubKey);
+                final PublicKey edPublicKey = Ed25519KeyFactory.getPublicKey(pubKeyBytes);
 
                 kp = new KeyPair(edPublicKey, edPrivateKey);
                 break;

--- a/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
+++ b/src/main/java/com/hierynomus/sshj/userauth/keyprovider/OpenSSHKeyV1KeyFile.java
@@ -76,13 +76,19 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
         SUPPORTED_CIPHERS.put(ChachaPolyCiphers.CHACHA_POLY_OPENSSH().getName(), ChachaPolyCiphers.CHACHA_POLY_OPENSSH());
     }
 
-    private PublicKey pubKey;
+    private final CompanionPublicKey companionPublicKey = new CompanionPublicKey();
     private SecurityKeySigner securityKeySigner;
 
     @Override
     public PublicKey getPublic()
             throws IOException {
-        return pubKey != null ? pubKey : super.getPublic();
+        return companionPublicKey.isPresent() ? companionPublicKey.getPublicKey() : super.getPublic();
+    }
+
+    @Override
+    public KeyType getType()
+            throws IOException {
+        return companionPublicKey.getType() != null ? companionPublicKey.getType() : super.getType();
     }
 
     /**
@@ -114,41 +120,19 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
 
     @Override
     public void init(File location, PasswordFinder pwdf) {
-        File publicKeyFile = OpenSSHKeyFileUtil.getPublicKeyFile(location);
-        if (publicKeyFile != null) {
-            try {
-                initPubKey(new FileReader(publicKeyFile));
-            } catch (IOException e) {
-                // let super provide both public & private key
-                log.warn("Error reading public key file: {}", e.toString());
-            }
-        }
+        companionPublicKey.loadSiblingOf(location);
         super.init(location, pwdf);
     }
 
     @Override
     public void init(String privateKey, String publicKey, PasswordFinder pwdf) {
-        if (publicKey != null) {
-            try {
-                initPubKey(new StringReader(publicKey));
-            } catch (IOException e) {
-                // let super provide both public & private key
-                log.warn("Error reading public key: {}", e.toString());
-            }
-        }
+        companionPublicKey.load(publicKey);
         super.init(privateKey, null, pwdf);
     }
 
     @Override
     public void init(Reader privateKey, Reader publicKey, PasswordFinder pwdf) {
-        if (publicKey != null) {
-            try {
-                initPubKey(publicKey);
-            } catch (IOException e) {
-                // let super provide both public & private key
-                log.warn("Error reading public key: {}", e.toString());
-            }
-        }
+        companionPublicKey.load(publicKey);
         super.init(privateKey, null, pwdf);
     }
 
@@ -174,12 +158,6 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
         }
     }
 
-    private void initPubKey(Reader publicKey) throws IOException {
-        OpenSSHKeyFileUtil.ParsedPubKey parsed = OpenSSHKeyFileUtil.initPubKey(publicKey);
-        type = parsed.getType();
-        pubKey = parsed.getPubKey();
-    }
-
     private KeyPair readDecodedKeyPair(final PlainBuffer keyBuffer) throws IOException, GeneralSecurityException {
         byte[] bytes = new byte[AUTH_MAGIC.length];
         keyBuffer.readRawBytes(bytes); // byte[] AUTH_MAGIC
@@ -196,7 +174,7 @@ public class OpenSSHKeyV1KeyFile extends BaseFileKeyProvider {
             final String message = String.format("OpenSSH Private Key number of keys not supported [%d]", nrKeys);
             throw new IOException(message);
         }
-        PublicKey publicKey = pubKey;
+        PublicKey publicKey = companionPublicKey.getPublicKey();
         if (publicKey == null) {
             publicKey = readPublicKey(new PlainBuffer(keyBuffer.readBytes()));
         } else {

--- a/src/main/java/net/schmizz/sshj/userauth/keyprovider/OpenSSHKeyFile.java
+++ b/src/main/java/net/schmizz/sshj/userauth/keyprovider/OpenSSHKeyFile.java
@@ -15,10 +15,13 @@
  */
 package net.schmizz.sshj.userauth.keyprovider;
 
-import com.hierynomus.sshj.userauth.keyprovider.OpenSSHKeyFileUtil;
+import com.hierynomus.sshj.userauth.keyprovider.CompanionPublicKey;
+import net.schmizz.sshj.common.KeyType;
 import net.schmizz.sshj.userauth.password.PasswordFinder;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
 import java.security.PublicKey;
 
 
@@ -46,63 +49,35 @@ public class OpenSSHKeyFile
         }
     }
 
-    private PublicKey pubKey;
+    private final CompanionPublicKey companionPublicKey = new CompanionPublicKey();
 
     @Override
     public PublicKey getPublic()
             throws IOException {
-        return pubKey != null ? pubKey : super.getPublic();
+        return companionPublicKey.isPresent() ? companionPublicKey.getPublicKey() : super.getPublic();
+    }
+
+    @Override
+    public KeyType getType()
+            throws IOException {
+        return companionPublicKey.getType() != null ? companionPublicKey.getType() : super.getType();
     }
 
     @Override
     public void init(File location, PasswordFinder pwdf) {
-        // try cert key location first
-        File publicKeyFile = OpenSSHKeyFileUtil.getPublicKeyFile(location);
-        if (publicKeyFile != null) {
-            try {
-                initPubKey(new FileReader(publicKeyFile));
-            } catch (IOException e) {
-                // let super provide both public & private key
-                log.warn("Error reading public key file: {}", e.toString());
-            }
-        }
+        companionPublicKey.loadSiblingOf(location);
         super.init(location, pwdf);
     }
 
     @Override
     public void init(String privateKey, String publicKey, PasswordFinder pwdf) {
-        if (publicKey != null) {
-            try {
-                initPubKey(new StringReader(publicKey));
-            } catch (IOException e) {
-                // let super provide both public & private key
-                log.warn("Error reading public key: {}", e.toString());
-            }
-        }
+        companionPublicKey.load(publicKey);
         super.init(privateKey, null, pwdf);
     }
 
     @Override
     public void init(Reader privateKey, Reader publicKey, PasswordFinder pwdf) {
-        if (publicKey != null) {
-            try {
-                initPubKey(publicKey);
-            } catch (IOException e) {
-                // let super provide both public & private key
-                log.warn("Error reading public key: {}", e.toString());
-            }
-        }
+        companionPublicKey.load(publicKey);
         super.init(privateKey, null, pwdf);
-    }
-
-    /**
-     * Read and store the separate public key provided alongside the private key
-     *
-     * @param publicKey Public key accessible through a {@code Reader}
-     */
-    private void initPubKey(Reader publicKey) throws IOException {
-        OpenSSHKeyFileUtil.ParsedPubKey parsed = OpenSSHKeyFileUtil.initPubKey(publicKey);
-        type = parsed.getType();
-        pubKey = parsed.getPubKey();
     }
 }

--- a/src/main/java/net/schmizz/sshj/userauth/keyprovider/OpenSSHKeyFile.java
+++ b/src/main/java/net/schmizz/sshj/userauth/keyprovider/OpenSSHKeyFile.java
@@ -57,10 +57,10 @@ public class OpenSSHKeyFile
     @Override
     public void init(File location, PasswordFinder pwdf) {
         // try cert key location first
-        File pubKey = OpenSSHKeyFileUtil.getPublicKeyFile(location);
-        if (pubKey != null) {
+        File publicKeyFile = OpenSSHKeyFileUtil.getPublicKeyFile(location);
+        if (publicKeyFile != null) {
             try {
-                initPubKey(new FileReader(pubKey));
+                initPubKey(new FileReader(publicKeyFile));
             } catch (IOException e) {
                 // let super provide both public & private key
                 log.warn("Error reading public key file: {}", e.toString());

--- a/src/test/java/net/schmizz/sshj/keyprovider/OpenSSHKeyFileTest.java
+++ b/src/test/java/net/schmizz/sshj/keyprovider/OpenSSHKeyFileTest.java
@@ -457,6 +457,17 @@ public class OpenSSHKeyFileTest {
     }
 
     @Test
+    public void shouldSuccessfullyLoadSignedRSACertificateFromStream() throws IOException {
+        FileKeyProvider keyFile = new OpenSSHKeyFile();
+        keyFile.init(new FileReader("src/test/resources/keytypes/certificate/test_rsa"),
+                new FileReader("src/test/resources/keytypes/certificate/test_rsa-cert.pub"),
+                PasswordUtils.createOneOff(correctPassphrase));
+        assertNotNull(keyFile.getPrivate());
+        assertTrue(keyFile.getPublic() instanceof Certificate, "Public key is not a certificate");
+        assertEquals(KeyType.RSA_CERT, keyFile.getType());
+    }
+
+    @Test
     public void shouldSuccessfullyLoadSignedRSAPublicKeyWithMaxDate() throws IOException {
         FileKeyProvider keyFile = new OpenSSHKeyFile();
         keyFile.init(new File("src/test/resources/keytypes/certificate/test_rsa_max_date"),

--- a/src/test/java/net/schmizz/sshj/keyprovider/OpenSSHKeyFileTest.java
+++ b/src/test/java/net/schmizz/sshj/keyprovider/OpenSSHKeyFileTest.java
@@ -338,6 +338,69 @@ public class OpenSSHKeyFileTest {
         assertThat(aPrivate.getAlgorithm(), equalTo("ECDSA"));
     }
 
+    private static final String OPENSSHV1_CERT_DIR = "src/itest/resources/keyfiles/certificates/";
+
+    /**
+     * When a certificate is supplied alongside an {@code openssh-key-v1} private key - as a string, a
+     * stream or a {@code -cert.pub} file - it must be used as the public key. Regression test for a
+     * bug where the {@code String}/{@code Reader} {@code init} overloads checked the (always {@code
+     * null}) {@code pubKey} field instead of their {@code publicKey} argument, silently dropping it.
+     */
+    @Test
+    public void shouldLoadRSACertificateAsOpenSSHV1() throws IOException {
+        assertOpenSSHV1CertificateLoaded("id_rsa_2048_rfc4716_signed_by_rsa",
+                KeyType.RSA_CERT, "RSA");
+    }
+
+    @Test
+    public void shouldLoadED25519CertificateAsOpenSSHV1() throws IOException {
+        assertOpenSSHV1CertificateLoaded("id_ed25519_384_rfc4716_signed_by_ed25519",
+                KeyType.ED25519_CERT, "Ed25519");
+    }
+
+    @Test
+    public void shouldLoadECDSACertificateAsOpenSSHV1() throws IOException {
+        assertOpenSSHV1CertificateLoaded("id_ecdsa_256_rfc4716_signed_by_ecdsa",
+                KeyType.ECDSA256_CERT, "ECDSA");
+    }
+
+    private void assertOpenSSHV1CertificateLoaded(String name, KeyType expectedType, String expectedPrivateAlgorithm)
+            throws IOException {
+        String privateKey = OPENSSHV1_CERT_DIR + name;
+        String publicKey = privateKey + "-cert.pub";
+
+        OpenSSHKeyV1KeyFile fromString = new OpenSSHKeyV1KeyFile();
+        fromString.init(readFile(privateKey), readFile(publicKey));
+        assertCertificate(fromString, expectedType, expectedPrivateAlgorithm);
+
+        OpenSSHKeyV1KeyFile fromStream = new OpenSSHKeyV1KeyFile();
+        fromStream.init(new FileReader(privateKey), new FileReader(publicKey));
+        assertCertificate(fromStream, expectedType, expectedPrivateAlgorithm);
+
+        OpenSSHKeyV1KeyFile fromFile = new OpenSSHKeyV1KeyFile();
+        fromFile.init(new File(privateKey));
+        assertCertificate(fromFile, expectedType, expectedPrivateAlgorithm);
+    }
+
+    private void assertCertificate(OpenSSHKeyV1KeyFile keyFile, KeyType expectedType, String expectedPrivateAlgorithm)
+            throws IOException {
+        assertEquals(expectedType, keyFile.getType());
+        assertTrue(keyFile.getPublic() instanceof Certificate, "Public key is not a certificate");
+        assertThat(keyFile.getPrivate().getAlgorithm(), equalTo(expectedPrivateAlgorithm));
+    }
+
+    /**
+     * A {@code null} public key argument means "no separate public key", so the key embedded in the
+     * private key file must be used.
+     */
+    @Test
+    public void shouldFallBackToEmbeddedPublicKeyWhenNoneSuppliedAsOpenSSHV1() throws IOException {
+        OpenSSHKeyV1KeyFile keyFile = new OpenSSHKeyV1KeyFile();
+        keyFile.init(readFile("src/test/resources/keyformats/rsa_opensshv1"), null);
+        assertTrue(keyFile.getPublic() instanceof RSAPublicKey);
+        assertThat(keyFile.getPrivate().getAlgorithm(), equalTo("RSA"));
+    }
+
     private void checkOpenSSHKeyV1(String key, final String password, boolean withRetry) throws IOException {
         OpenSSHKeyV1KeyFile keyFile = new OpenSSHKeyV1KeyFile();
         WipeTrackingPasswordFinder pwf = new WipeTrackingPasswordFinder(password, withRetry);


### PR DESCRIPTION
Prepares for a bigger refactor of key parsing to break the inheritance for implementation use.
Replaces #944 